### PR TITLE
Restructure Options and Transport functionality to become generic

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -18,7 +18,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -37,15 +36,6 @@ const (
 	// be arbitrary, even unset, as it is not respected server-side. For conventions'
 	// sake, we'll set this to "git".
 	patUsername = "git"
-)
-
-var (
-	// ErrInvalidClientOptions is the error returned when calling NewClient() with
-	// invalid options (e.g. specifying mutually exclusive options).
-	ErrInvalidClientOptions = errors.New("invalid options given to NewClient()")
-	// ErrDestructiveCallDisallowed happens when the client isn't set up with WithDestructiveAPICalls()
-	// but a destructive action is called.
-	ErrDestructiveCallDisallowed = errors.New("a destructive call was blocked because it wasn't allowed by the client")
 )
 
 // clientOptions is the struct that tracks data about what options have been set
@@ -84,11 +74,11 @@ func WithOAuth2Token(oauth2Token string) ClientOption {
 	return func(opts *clientOptions) error {
 		// Don't allow an empty value
 		if len(oauth2Token) == 0 {
-			return fmt.Errorf("oauth2Token cannot be empty: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("oauth2Token cannot be empty: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		// Make sure the user didn't specify auth twice
 		if opts.authTransportFactory != nil {
-			return fmt.Errorf("authentication http.Client already configured: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("authentication http.Client already configured: %w", gitprovider.ErrInvalidClientOptions)
 		}
 
 		opts.authTransportFactory = &oauth2Auth{oauth2Token}
@@ -103,11 +93,11 @@ func WithPersonalAccessToken(patToken string) ClientOption {
 	return func(opts *clientOptions) error {
 		// Don't allow an empty value
 		if len(patToken) == 0 {
-			return fmt.Errorf("patToken cannot be empty: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("patToken cannot be empty: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		// Make sure the user didn't specify auth twice
 		if opts.authTransportFactory != nil {
-			return fmt.Errorf("authentication http.Client already configured: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("authentication http.Client already configured: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		opts.authTransportFactory = &patAuth{patToken}
 		return nil
@@ -120,11 +110,11 @@ func WithRoundTripper(roundTripper RoundTripperFactory) ClientOption {
 	return func(opts *clientOptions) error {
 		// Don't allow an empty value
 		if roundTripper == nil {
-			return fmt.Errorf("roundTripper cannot be nil: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("roundTripper cannot be nil: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		// Make sure the user didn't specify the RoundTripperFactory twice
 		if opts.RoundTripperFactory != nil {
-			return fmt.Errorf("roundTripper already configured: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("roundTripper already configured: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		opts.RoundTripperFactory = roundTripper
 		return nil
@@ -137,11 +127,11 @@ func WithDomain(domain string) ClientOption {
 	return func(opts *clientOptions) error {
 		// Don't set an empty value
 		if len(domain) == 0 {
-			return fmt.Errorf("domain cannot be empty: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("domain cannot be empty: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		// Make sure the user didn't specify the domain twice
 		if opts.Domain != nil {
-			return fmt.Errorf("domain already configured: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("domain already configured: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		opts.Domain = gitprovider.StringVar(domain)
 		return nil
@@ -154,7 +144,7 @@ func WithDestructiveAPICalls(destructiveActions bool) ClientOption {
 	return func(opts *clientOptions) error {
 		// Make sure the user didn't specify the flag twice
 		if opts.EnableDestructiveAPICalls != nil {
-			return fmt.Errorf("destructive actions flag already configured: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("destructive actions flag already configured: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		opts.EnableDestructiveAPICalls = gitprovider.BoolVar(destructiveActions)
 		return nil
@@ -168,7 +158,7 @@ func WithConditionalRequests(conditionalRequests bool) ClientOption {
 	return func(opts *clientOptions) error {
 		// Make sure the user didn't specify the flag twice
 		if opts.EnableConditionalRequests != nil {
-			return fmt.Errorf("conditional requests flag already configured: %w", ErrInvalidClientOptions)
+			return fmt.Errorf("conditional requests flag already configured: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		opts.EnableConditionalRequests = gitprovider.BoolVar(conditionalRequests)
 		return nil
@@ -312,7 +302,7 @@ func buildTransportChain(ctx context.Context, opts *clientOptions) (http.RoundTr
 		if customTransport == nil {
 			// The lint failure here is a false positive, for some (unknown) reason
 			//nolint:goerr113
-			return nil, fmt.Errorf("the RoundTripper returned from the RoundTripperFactory must not be nil: %w", ErrInvalidClientOptions)
+			return nil, fmt.Errorf("the RoundTripper returned from the RoundTripperFactory must not be nil: %w", gitprovider.ErrInvalidClientOptions)
 		}
 		transport = customTransport
 	}

--- a/github/auth.go
+++ b/github/auth.go
@@ -152,8 +152,8 @@ func WithPreChainTransportHook(preRoundTripperFunc gitprovider.ChainableRoundTri
 	return buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: preRoundTripperFunc})
 }
 
-// WithPostChainTransportHook registers a ChainableRoundTripperFunc "before" the cache and authentication
-// transports in the chain. For more information, see NewClient, and gitprovider.CommonClientOptions.PreChainTransportHook.
+// WithPostChainTransportHook registers a ChainableRoundTripperFunc "after" the cache and authentication
+// transports in the chain. For more information, see NewClient, and gitprovider.CommonClientOptions.WithPostChainTransportHook.
 func WithPostChainTransportHook(postRoundTripperFunc gitprovider.ChainableRoundTripperFunc) ClientOption {
 	// Don't allow an empty value
 	if postRoundTripperFunc == nil {

--- a/github/auth_test.go
+++ b/github/auth_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/fluxcd/go-git-providers/gitprovider/cache"
+	"github.com/fluxcd/go-git-providers/validation"
+)
+
+func dummyRoundTripper1(http.RoundTripper) http.RoundTripper { return nil }
+func dummyRoundTripper2(http.RoundTripper) http.RoundTripper { return nil }
+func dummyRoundTripper3(http.RoundTripper) http.RoundTripper { return nil }
+
+func roundTrippersEqual(a, b gitprovider.ChainableRoundTripperFunc) bool {
+	if a == nil && b == nil {
+		return true
+	} else if (a != nil && b == nil) || (a == nil && b != nil) {
+		return false
+	}
+	// Note that this comparison relies on "undefined behavior" in the Go language spec, see:
+	// https://stackoverflow.com/questions/9643205/how-do-i-compare-two-functions-for-pointer-equality-in-the-latest-go-weekly
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
+
+func Test_clientOptions_getTransportChain(t *testing.T) {
+	tests := []struct {
+		name      string
+		preChain  gitprovider.ChainableRoundTripperFunc
+		postChain gitprovider.ChainableRoundTripperFunc
+		auth      gitprovider.ChainableRoundTripperFunc
+		cache     bool
+		wantChain []gitprovider.ChainableRoundTripperFunc
+	}{
+		{
+			name:      "all roundtrippers",
+			preChain:  dummyRoundTripper1,
+			postChain: dummyRoundTripper2,
+			auth:      dummyRoundTripper3,
+			cache:     true,
+			// expect: "post chain" <-> "auth" <-> "cache" <-> "pre chain"
+			wantChain: []gitprovider.ChainableRoundTripperFunc{
+				dummyRoundTripper2,
+				dummyRoundTripper3,
+				cache.NewHTTPCacheTransport,
+				dummyRoundTripper1,
+			},
+		},
+		{
+			name:     "only pre + auth",
+			preChain: dummyRoundTripper1,
+			auth:     dummyRoundTripper2,
+			// expect: "auth" <-> "pre chain"
+			wantChain: []gitprovider.ChainableRoundTripperFunc{
+				dummyRoundTripper2,
+				dummyRoundTripper1,
+			},
+		},
+		{
+			name:  "only cache + auth",
+			cache: true,
+			auth:  dummyRoundTripper1,
+			// expect: "auth" <-> "cache"
+			wantChain: []gitprovider.ChainableRoundTripperFunc{
+				dummyRoundTripper1,
+				cache.NewHTTPCacheTransport,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &clientOptions{
+				CommonClientOptions: gitprovider.CommonClientOptions{
+					PreChainTransportHook:  tt.preChain,
+					PostChainTransportHook: tt.postChain,
+				},
+				AuthTransport:             tt.auth,
+				EnableConditionalRequests: &tt.cache,
+			}
+			gotChain := opts.getTransportChain()
+			for i := range tt.wantChain {
+				if !roundTrippersEqual(tt.wantChain[i], gotChain[i]) {
+					t.Errorf("clientOptions.getTransportChain() = %v, want %v", gotChain, tt.wantChain)
+				}
+				break
+			}
+		})
+	}
+}
+
+func Test_makeOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         []ClientOption
+		want         *clientOptions
+		expectedErrs []error
+	}{
+		{
+			name: "no options",
+			want: &clientOptions{},
+		},
+		{
+			name: "WithDomain",
+			opts: []ClientOption{WithDomain("foo")},
+			want: buildCommonOption(gitprovider.CommonClientOptions{Domain: gitprovider.StringVar("foo")}),
+		},
+		{
+			name:         "WithDomain, empty",
+			opts:         []ClientOption{WithDomain("")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithDestructiveAPICalls",
+			opts: []ClientOption{WithDestructiveAPICalls(true)},
+			want: buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: gitprovider.BoolVar(true)}),
+		},
+		{
+			name: "WithPreChainTransportHook",
+			opts: []ClientOption{WithPreChainTransportHook(dummyRoundTripper1)},
+			want: buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: dummyRoundTripper1}),
+		},
+		{
+			name:         "WithPreChainTransportHook, nil",
+			opts:         []ClientOption{WithPreChainTransportHook(nil)},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithPostChainTransportHook",
+			opts: []ClientOption{WithPostChainTransportHook(dummyRoundTripper2)},
+			want: buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: dummyRoundTripper2}),
+		},
+		{
+			name:         "WithPostChainTransportHook, nil",
+			opts:         []ClientOption{WithPostChainTransportHook(nil)},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithOAuth2Token",
+			opts: []ClientOption{WithOAuth2Token("foo")},
+			want: &clientOptions{AuthTransport: oauth2Transport("foo")},
+		},
+		{
+			name:         "WithOAuth2Token, empty",
+			opts:         []ClientOption{WithOAuth2Token("")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithPersonalAccessToken",
+			opts: []ClientOption{WithPersonalAccessToken("foo")},
+			want: &clientOptions{AuthTransport: patTransport("foo")},
+		},
+		{
+			name:         "WithPersonalAccessToken, empty",
+			opts:         []ClientOption{WithPersonalAccessToken("")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name:         "WithPersonalAccessToken and WithOAuth2Token, exclusive",
+			opts:         []ClientOption{WithPersonalAccessToken("foo"), WithOAuth2Token("foo")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithConditionalRequests",
+			opts: []ClientOption{WithConditionalRequests(true)},
+			want: &clientOptions{EnableConditionalRequests: gitprovider.BoolVar(true)},
+		},
+		{
+			name:         "WithConditionalRequests, exclusive",
+			opts:         []ClientOption{WithConditionalRequests(true), WithConditionalRequests(false)},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeOptions(tt.opts...)
+			validation.TestExpectErrors(t, "makeOptions", err, tt.expectedErrs...)
+			if tt.want == nil {
+				return
+			}
+			if !roundTrippersEqual(got.AuthTransport, tt.want.AuthTransport) ||
+				!roundTrippersEqual(got.PostChainTransportHook, tt.want.PostChainTransportHook) ||
+				!roundTrippersEqual(got.PreChainTransportHook, tt.want.PreChainTransportHook) {
+				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
+			}
+			got.AuthTransport = nil
+			got.PostChainTransportHook = nil
+			got.PreChainTransportHook = nil
+			tt.want.AuthTransport = nil
+			tt.want.PostChainTransportHook = nil
+			tt.want.PreChainTransportHook = nil
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/github/example_organization_test.go
+++ b/github/example_organization_test.go
@@ -20,7 +20,7 @@ func checkErr(err error) {
 func ExampleOrganizationsClient_Get() {
 	// Create a new client
 	ctx := context.Background()
-	c, err := github.NewClient(ctx)
+	c, err := github.NewClient()
 	checkErr(err)
 
 	// Get public information about the fluxcd organization

--- a/github/example_repository_test.go
+++ b/github/example_repository_test.go
@@ -12,7 +12,7 @@ import (
 func ExampleOrgRepositoriesClient_Get() {
 	// Create a new client
 	ctx := context.Background()
-	c, err := github.NewClient(ctx)
+	c, err := github.NewClient()
 	checkErr(err)
 
 	// Parse the URL into an OrgRepositoryRef

--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -262,7 +262,7 @@ func (c *githubClientImpl) UpdateRepo(ctx context.Context, owner, repo string, r
 func (c *githubClientImpl) DeleteRepo(ctx context.Context, owner, repo string) error {
 	// Don't allow deleting repositories if the user didn't explicitly allow dangerous API calls.
 	if !c.destructiveActions {
-		return fmt.Errorf("cannot delete repository: %w", ErrDestructiveCallDisallowed)
+		return fmt.Errorf("cannot delete repository: %w", gitprovider.ErrDestructiveCallDisallowed)
 	}
 	// DELETE /repos/{owner}/{repo}
 	_, err := c.c.Repositories.Delete(ctx, owner, repo)

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -126,7 +126,7 @@ func (t *customTransport) countCacheHitsForFunc(fn func()) int {
 
 var _ = Describe("GitHub Provider", func() {
 	var (
-		ctx context.Context
+		ctx context.Context = context.Background()
 		c   gitprovider.Client
 
 		testRepoName string
@@ -148,13 +148,12 @@ var _ = Describe("GitHub Provider", func() {
 			testOrgName = orgName
 		}
 
-		ctx = context.Background()
 		var err error
-		c, err = NewClient(ctx,
+		c, err = NewClient(
 			WithPersonalAccessToken(githubToken),
 			WithDestructiveAPICalls(true),
 			WithConditionalRequests(true),
-			WithRoundTripper(customTransportFactory),
+			WithPreChainTransportHook(customTransportFactory),
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -45,6 +45,11 @@ const (
 	defaultBranch = "master"
 )
 
+var (
+	// customTransportImpl is a shared instance of a customTransport, allowing counting of cache hits.
+	customTransportImpl *customTransport
+)
+
 func init() {
 	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
 	testing.Init()
@@ -56,21 +61,17 @@ func TestProvider(t *testing.T) {
 	RunSpecs(t, "GitHub Provider Suite")
 }
 
-type customTransportFactory struct {
-	customTransport *customTransport
-}
-
-func (f *customTransportFactory) Transport(transport http.RoundTripper) http.RoundTripper {
-	if f.customTransport != nil {
+func customTransportFactory(transport http.RoundTripper) http.RoundTripper {
+	if customTransportImpl != nil {
 		panic("didn't expect this function to be called twice")
 	}
-	f.customTransport = &customTransport{
+	customTransportImpl = &customTransport{
 		transport:      transport,
 		countCacheHits: false,
 		cacheHits:      0,
 		mux:            &sync.Mutex{},
 	}
-	return f.customTransport
+	return customTransportImpl
 }
 
 type customTransport struct {
@@ -125,9 +126,8 @@ func (t *customTransport) countCacheHitsForFunc(fn func()) int {
 
 var _ = Describe("GitHub Provider", func() {
 	var (
-		ctx              context.Context
-		c                gitprovider.Client
-		transportFactory = &customTransportFactory{}
+		ctx context.Context
+		c   gitprovider.Client
 
 		testRepoName string
 		testOrgName  string = "fluxcd-testing"
@@ -154,7 +154,7 @@ var _ = Describe("GitHub Provider", func() {
 			WithPersonalAccessToken(githubToken),
 			WithDestructiveAPICalls(true),
 			WithConditionalRequests(true),
-			WithRoundTripper(transportFactory),
+			WithRoundTripper(customTransportFactory),
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -174,7 +174,7 @@ var _ = Describe("GitHub Provider", func() {
 		}
 		Expect(listedOrg).ToNot(BeNil())
 
-		hits := transportFactory.customTransport.countCacheHitsForFunc(func() {
+		hits := customTransportImpl.countCacheHitsForFunc(func() {
 			// Do a GET call for that organization
 			getOrg, err = c.Organizations().Get(ctx, listedOrg.Organization())
 			Expect(err).ToNot(HaveOccurred())
@@ -200,7 +200,7 @@ var _ = Describe("GitHub Provider", func() {
 		Expect(getOrg.Get().Description).To(Equal(internal.Description))
 
 		// Expect that when we do the same request a second time, it will hit the cache
-		hits = transportFactory.customTransport.countCacheHitsForFunc(func() {
+		hits = customTransportImpl.countCacheHitsForFunc(func() {
 			getOrg2, err := c.Organizations().Get(ctx, listedOrg.Organization())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getOrg2).ToNot(BeNil())

--- a/gitprovider/cache/httpcache.go
+++ b/gitprovider/cache/httpcache.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"net/http"
+
+	"github.com/gregjones/httpcache"
+)
+
+// TODO: Implement an unit test for this package.
+
+// NewHTTPCacheTransport is a gitprovider.ChainableRoundTripperFunc which adds
+// HTTP Conditional Requests caching for the backend, if the server supports it.
+func NewHTTPCacheTransport(in http.RoundTripper) http.RoundTripper {
+	// Create a new httpcache high-level Transport
+	t := httpcache.NewMemoryCacheTransport()
+	// Configure the httpcache Transport to use in as its underlying Transport.
+	// If in is nil, http.DefaultTransport will be used.
+	t.Transport = in
+	// Set "out" to use a slightly custom variant of the httpcache Transport
+	// (with more aggressive cache invalidation)
+	return &cacheRoundtripper{Transport: t}
+}
+
+// cacheRoundtripper is a slight wrapper around *httpcache.Transport that automatically
+// invalidates the cache on non-GET/HEAD requests, and non-"200 OK" responses.
+type cacheRoundtripper struct {
+	Transport *httpcache.Transport
+}
+
+// This function follows the same logic as in github.com/gregjones/httpcache to be able
+// to implement our custom roundtripper logic below.
+func cacheKey(req *http.Request) string {
+	if req.Method == http.MethodGet {
+		return req.URL.String()
+	}
+	return req.Method + " " + req.URL.String()
+}
+
+// RoundTrip calls the underlying RoundTrip (using the cache), but invalidates the cache on
+// non GET/HEAD requests and non-"200 OK" responses.
+func (r *cacheRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// These two statements are the same as in github.com/gregjones/httpcache Transport.RoundTrip
+	// to be able to implement our custom roundtripper below
+	cacheKey := cacheKey(req)
+	cacheable := (req.Method == "GET" || req.Method == "HEAD") && req.Header.Get("range") == ""
+
+	// If the object isn't a GET or HEAD request, also invalidate the cache of the GET URL
+	// as this action will modify the underlying resource (e.g. DELETE/POST/PATCH)
+	if !cacheable {
+		r.Transport.Cache.Delete(req.URL.String())
+	}
+	// Call the underlying roundtrip
+	resp, err := r.Transport.RoundTrip(req)
+	// Don't cache anything but "200 OK" requests
+	if resp.StatusCode != http.StatusOK {
+		r.Transport.Cache.Delete(cacheKey)
+	}
+	return resp, err
+}

--- a/gitprovider/client_options.go
+++ b/gitprovider/client_options.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitprovider
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ChainableRoundTripperFunc is a function that returns a higher-level "out" RoundTripper,
+// chained to call the "in" RoundTripper internally, with extra logic. This function must be able
+// to handle "in" being nil, and use the http.DefaultTransport default RoundTripper in that case.
+// "out" must never be nil.
+type ChainableRoundTripperFunc func(in http.RoundTripper) (out http.RoundTripper)
+
+// CommonClientOptions is a struct containing options that are generic to all clients.
+type CommonClientOptions struct {
+	// Domain specifies the target domain for the client. If unset, the default domain for the
+	// given provider will be used (often exposed as DefaultDomain in respective package).
+	// The behaviour when setting this flag might vary between providers, read the documentation on
+	// NewClient for more information.
+	Domain *string
+
+	// EnableDestructiveAPICalls is a flag specifying whether destructive API calls (like
+	// deleting a repository) are allowed in the Client. Default: false
+	EnableDestructiveAPICalls *bool
+
+	// PreChainRoundTripper is a function to get a custom RoundTripper that is given as the Transport
+	// to the *http.Client given to the provider-specific Client. It can be set for doing arbitrary
+	// modifications to HTTP requests. "in" might be nil, if so http.DefaultTransport is recommended.
+	// The "chain" looks like follows:
+	// Git provider API <-> "Post Chain" <-> Provider Specific (e.g. auth, caching) (in) <-> "Pre Chain" (out) <-> *http.Client
+	PreChainTransportHook ChainableRoundTripperFunc
+
+	// PostChainTransportHook is a function to get a custom RoundTripper that is the "final" Transport
+	// in the chain before talking to the backing API. It can be set for doing arbitrary
+	// modifications to HTTP requests. "in" is always nil. It's recommended to internally use http.DefaultTransport.
+	// The "chain" looks like follows:
+	// Git provider API (in==nil) <-> "Post Chain" (out) <-> Provider Specific (e.g. auth, caching) <-> "Pre Chain" <-> *http.Client
+	PostChainTransportHook ChainableRoundTripperFunc
+}
+
+// ApplyToCommonClientOptions applies the currently set fields in opts to target. If both opts and
+// target has the same specific field set, ErrInvalidClientOptions is returned.
+func (opts *CommonClientOptions) ApplyToCommonClientOptions(target *CommonClientOptions) error {
+	if opts.Domain != nil {
+		// Make sure the user didn't specify the Domain twice
+		if target.Domain != nil {
+			return fmt.Errorf("option Domain already configured: %w", ErrInvalidClientOptions)
+		}
+		// Don't allow an empty string
+		if len(*opts.Domain) == 0 {
+			return fmt.Errorf("option Domain cannot be an empty string: %w", ErrInvalidClientOptions)
+		}
+		target.Domain = opts.Domain
+	}
+
+	if opts.EnableDestructiveAPICalls != nil {
+		// Make sure the user didn't specify the EnableDestructiveAPICalls twice
+		if target.EnableDestructiveAPICalls != nil {
+			return fmt.Errorf("option EnableDestructiveAPICalls already configured: %w", ErrInvalidClientOptions)
+		}
+		target.EnableDestructiveAPICalls = opts.EnableDestructiveAPICalls
+	}
+
+	if opts.PreChainTransportHook != nil {
+		// Make sure the user didn't specify the PreChainTransportHook twice
+		if target.PreChainTransportHook != nil {
+			return fmt.Errorf("option PreChainTransportHook already configured: %w", ErrInvalidClientOptions)
+		}
+		target.PreChainTransportHook = opts.PreChainTransportHook
+	}
+
+	if opts.PostChainTransportHook != nil {
+		// Make sure the user didn't specify the PostChainTransportHook twice
+		if target.PostChainTransportHook != nil {
+			return fmt.Errorf("option PostChainTransportHook already configured: %w", ErrInvalidClientOptions)
+		}
+		target.PostChainTransportHook = opts.PostChainTransportHook
+	}
+	return nil
+}
+
+// BuildClientFromTransportChain builds a *http.Client from a chain of ChainableRoundTripperFuncs.
+// The first function in the chain is called with "in" == nil. "out" of the first function in the chain,
+// is passed as "in" to the second function, and so on. "out" of the last function in the chain is used
+// as net/http Client.Transport.
+func BuildClientFromTransportChain(chain []ChainableRoundTripperFunc) (*http.Client, error) {
+	var transport http.RoundTripper
+	for _, rtFunc := range chain {
+		transport = rtFunc(transport)
+		if transport == nil {
+			return nil, ErrInvalidTransportChainReturn
+		}
+	}
+	return &http.Client{Transport: transport}, nil
+}

--- a/gitprovider/client_options_test.go
+++ b/gitprovider/client_options_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitprovider
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/fluxcd/go-git-providers/validation"
+)
+
+func roundTrippersEqual(a, b ChainableRoundTripperFunc) bool {
+	if a == nil && b == nil {
+		return true
+	} else if (a != nil && b == nil) || (a == nil && b != nil) {
+		return false
+	}
+	// Note that this comparison relies on "undefined behavior" in the Go language spec, see:
+	// https://stackoverflow.com/questions/9643205/how-do-i-compare-two-functions-for-pointer-equality-in-the-latest-go-weekly
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
+
+type commonClientOption interface {
+	ApplyToCommonClientOptions(*CommonClientOptions) error
+}
+
+func makeOptions(opts ...commonClientOption) (*CommonClientOptions, error) {
+	o := &CommonClientOptions{}
+	for _, opt := range opts {
+		if err := opt.ApplyToCommonClientOptions(o); err != nil {
+			return nil, err
+		}
+	}
+	return o, nil
+}
+
+func withDomain(domain string) commonClientOption {
+	return &CommonClientOptions{Domain: &domain}
+}
+
+func withDestructiveAPICalls(destructiveActions bool) commonClientOption {
+	return &CommonClientOptions{EnableDestructiveAPICalls: &destructiveActions}
+}
+
+func withPreChainTransportHook(preRoundTripperFunc ChainableRoundTripperFunc) commonClientOption {
+	return &CommonClientOptions{PreChainTransportHook: preRoundTripperFunc}
+}
+
+func withPostChainTransportHook(postRoundTripperFunc ChainableRoundTripperFunc) commonClientOption {
+	return &CommonClientOptions{PostChainTransportHook: postRoundTripperFunc}
+}
+
+func dummyRoundTripper1(http.RoundTripper) http.RoundTripper { return nil }
+
+func Test_makeOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         []commonClientOption
+		want         *CommonClientOptions
+		expectedErrs []error
+	}{
+		{
+			name: "no options",
+			want: &CommonClientOptions{},
+		},
+		{
+			name: "withDomain",
+			opts: []commonClientOption{withDomain("foo")},
+			want: &CommonClientOptions{Domain: StringVar("foo")},
+		},
+		{
+			name:         "withDomain, empty",
+			opts:         []commonClientOption{withDomain("")},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name:         "withDomain, duplicate",
+			opts:         []commonClientOption{withDomain("foo"), withDomain("bar")},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "withDestructiveAPICalls",
+			opts: []commonClientOption{withDestructiveAPICalls(true)},
+			want: &CommonClientOptions{EnableDestructiveAPICalls: BoolVar(true)},
+		},
+		{
+			name:         "withDestructiveAPICalls, duplicate",
+			opts:         []commonClientOption{withDestructiveAPICalls(true), withDestructiveAPICalls(false)},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "withPreChainTransportHook",
+			opts: []commonClientOption{withPreChainTransportHook(dummyRoundTripper1)},
+			want: &CommonClientOptions{PreChainTransportHook: dummyRoundTripper1},
+		},
+		{
+			name:         "withPreChainTransportHook, duplicate",
+			opts:         []commonClientOption{withPreChainTransportHook(dummyRoundTripper1), withPreChainTransportHook(dummyRoundTripper1)},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "withPostChainTransportHook",
+			opts: []commonClientOption{withPostChainTransportHook(dummyRoundTripper1)},
+			want: &CommonClientOptions{PostChainTransportHook: dummyRoundTripper1},
+		},
+		{
+			name:         "withPostChainTransportHook, duplicate",
+			opts:         []commonClientOption{withPostChainTransportHook(dummyRoundTripper1), withPostChainTransportHook(dummyRoundTripper1)},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		/*{
+			name: "WithDestructiveAPICalls",
+			opts: []ClientOption{WithDestructiveAPICalls(true)},
+			want: buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: gitprovider.BoolVar(true)}),
+		},
+		{
+			name: "WithPreChainTransportHook",
+			opts: []ClientOption{WithPreChainTransportHook(dummyRoundTripper1)},
+			want: buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: dummyRoundTripper1}),
+		},
+		{
+			name:         "WithPreChainTransportHook, nil",
+			opts:         []ClientOption{WithPreChainTransportHook(nil)},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithPostChainTransportHook",
+			opts: []ClientOption{WithPostChainTransportHook(dummyRoundTripper2)},
+			want: buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: dummyRoundTripper2}),
+		},
+		{
+			name:         "WithPostChainTransportHook, nil",
+			opts:         []ClientOption{WithPostChainTransportHook(nil)},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithOAuth2Token",
+			opts: []ClientOption{WithOAuth2Token("foo")},
+			want: &clientOptions{AuthTransport: oauth2Transport("foo")},
+		},
+		{
+			name:         "WithOAuth2Token, empty",
+			opts:         []ClientOption{WithOAuth2Token("")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithPersonalAccessToken",
+			opts: []ClientOption{WithPersonalAccessToken("foo")},
+			want: &clientOptions{AuthTransport: patTransport("foo")},
+		},
+		{
+			name:         "WithPersonalAccessToken, empty",
+			opts:         []ClientOption{WithPersonalAccessToken("")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name:         "WithPersonalAccessToken and WithOAuth2Token, exclusive",
+			opts:         []ClientOption{WithPersonalAccessToken("foo"), WithOAuth2Token("foo")},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},
+		{
+			name: "WithConditionalRequests",
+			opts: []ClientOption{WithConditionalRequests(true)},
+			want: &clientOptions{EnableConditionalRequests: gitprovider.BoolVar(true)},
+		},
+		{
+			name:         "WithConditionalRequests, exclusive",
+			opts:         []ClientOption{WithConditionalRequests(true), WithConditionalRequests(false)},
+			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+		},*/
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeOptions(tt.opts...)
+			validation.TestExpectErrors(t, "makeOptions", err, tt.expectedErrs...)
+			if tt.want == nil {
+				return
+			}
+			if !roundTrippersEqual(got.PostChainTransportHook, tt.want.PostChainTransportHook) ||
+				!roundTrippersEqual(got.PreChainTransportHook, tt.want.PreChainTransportHook) {
+				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
+			}
+			got.PostChainTransportHook = nil
+			got.PreChainTransportHook = nil
+			tt.want.PostChainTransportHook = nil
+			tt.want.PreChainTransportHook = nil
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gitprovider/client_options_test.go
+++ b/gitprovider/client_options_test.go
@@ -123,66 +123,6 @@ func Test_makeOptions(t *testing.T) {
 			opts:         []commonClientOption{withPostChainTransportHook(dummyRoundTripper1), withPostChainTransportHook(dummyRoundTripper1)},
 			expectedErrs: []error{ErrInvalidClientOptions},
 		},
-		/*{
-			name: "WithDestructiveAPICalls",
-			opts: []ClientOption{WithDestructiveAPICalls(true)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: gitprovider.BoolVar(true)}),
-		},
-		{
-			name: "WithPreChainTransportHook",
-			opts: []ClientOption{WithPreChainTransportHook(dummyRoundTripper1)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: dummyRoundTripper1}),
-		},
-		{
-			name:         "WithPreChainTransportHook, nil",
-			opts:         []ClientOption{WithPreChainTransportHook(nil)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithPostChainTransportHook",
-			opts: []ClientOption{WithPostChainTransportHook(dummyRoundTripper2)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: dummyRoundTripper2}),
-		},
-		{
-			name:         "WithPostChainTransportHook, nil",
-			opts:         []ClientOption{WithPostChainTransportHook(nil)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithOAuth2Token",
-			opts: []ClientOption{WithOAuth2Token("foo")},
-			want: &clientOptions{AuthTransport: oauth2Transport("foo")},
-		},
-		{
-			name:         "WithOAuth2Token, empty",
-			opts:         []ClientOption{WithOAuth2Token("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithPersonalAccessToken",
-			opts: []ClientOption{WithPersonalAccessToken("foo")},
-			want: &clientOptions{AuthTransport: patTransport("foo")},
-		},
-		{
-			name:         "WithPersonalAccessToken, empty",
-			opts:         []ClientOption{WithPersonalAccessToken("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name:         "WithPersonalAccessToken and WithOAuth2Token, exclusive",
-			opts:         []ClientOption{WithPersonalAccessToken("foo"), WithOAuth2Token("foo")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithConditionalRequests",
-			opts: []ClientOption{WithConditionalRequests(true)},
-			want: &clientOptions{EnableConditionalRequests: gitprovider.BoolVar(true)},
-		},
-		{
-			name:         "WithConditionalRequests, exclusive",
-			opts:         []ClientOption{WithConditionalRequests(true), WithConditionalRequests(false)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gitprovider/errors.go
+++ b/gitprovider/errors.go
@@ -60,6 +60,8 @@ var (
 	// ErrDestructiveCallDisallowed happens when the client isn't set up with WithDestructiveAPICalls()
 	// but a destructive action is called.
 	ErrDestructiveCallDisallowed = errors.New("a destructive call was blocked because it wasn't allowed by the client")
+	// ErrInvalidTransportChainReturn is returned if a ChainableRoundTripperFunc returns nil, which is invalid.
+	ErrInvalidTransportChainReturn = errors.New("the return value of a ChainableRoundTripperFunc must not be nil")
 )
 
 // HTTPError is an error that contains context about the HTTP request/response that failed.

--- a/gitprovider/errors.go
+++ b/gitprovider/errors.go
@@ -59,7 +59,7 @@ var (
 	ErrInvalidClientOptions = errors.New("invalid options given to NewClient()")
 	// ErrDestructiveCallDisallowed happens when the client isn't set up with WithDestructiveAPICalls()
 	// but a destructive action is called.
-	ErrDestructiveCallDisallowed = errors.New("a destructive call was blocked because it wasn't allowed by the client")
+	ErrDestructiveCallDisallowed = errors.New("destructive call was blocked, disallowed by client")
 	// ErrInvalidTransportChainReturn is returned if a ChainableRoundTripperFunc returns nil, which is invalid.
 	ErrInvalidTransportChainReturn = errors.New("the return value of a ChainableRoundTripperFunc must not be nil")
 )

--- a/gitprovider/errors.go
+++ b/gitprovider/errors.go
@@ -53,6 +53,13 @@ var (
 	ErrURLInvalid = errors.New("invalid organization, user or repository URL")
 	// ErrURLMissingRepoName is returned if there is no repository name in the URL.
 	ErrURLMissingRepoName = errors.New("missing repository name")
+
+	// ErrInvalidClientOptions is the error returned when calling NewClient() with
+	// invalid options (e.g. specifying mutually exclusive options).
+	ErrInvalidClientOptions = errors.New("invalid options given to NewClient()")
+	// ErrDestructiveCallDisallowed happens when the client isn't set up with WithDestructiveAPICalls()
+	// but a destructive action is called.
+	ErrDestructiveCallDisallowed = errors.New("a destructive call was blocked because it wasn't allowed by the client")
 )
 
 // HTTPError is an error that contains context about the HTTP request/response that failed.


### PR DESCRIPTION
And code can be shared across providers.
~~Please look at only the last 3 commits, as this is besed on #26~~ **EDIT**: Now rebased and ready-to-merge.
@dinosk @twelho please review