### PR TITLE
Use Authorization header for Github PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Features
 
 - **Consistency:** Using the same Client interface and high-level structs for multiple backends.
-- **Authentication:** Personal Access Tokens, OAuth2 Tokens, and unauthenticated.
+- **Authentication:** Personal Access Tokens/OAuth2 Tokens, and unauthenticated.
 - **Pagination:** List calls automatically return all available pages.
 - **Conditional Requests:** Asks the Git provider if cached data is up-to-date before requesting, to avoid being rate limited.
 - **Reconciling:** Support reconciling desired state towards actual state and drift detection.

--- a/github/auth_test.go
+++ b/github/auth_test.go
@@ -163,21 +163,6 @@ func Test_makeOptions(t *testing.T) {
 			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
 		},
 		{
-			name: "WithPersonalAccessToken",
-			opts: []ClientOption{WithPersonalAccessToken("foo")},
-			want: &clientOptions{AuthTransport: patTransport("foo")},
-		},
-		{
-			name:         "WithPersonalAccessToken, empty",
-			opts:         []ClientOption{WithPersonalAccessToken("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name:         "WithPersonalAccessToken and WithOAuth2Token, exclusive",
-			opts:         []ClientOption{WithPersonalAccessToken("foo"), WithOAuth2Token("foo")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
 			name: "WithConditionalRequests",
 			opts: []ClientOption{WithConditionalRequests(true)},
 			want: &clientOptions{EnableConditionalRequests: gitprovider.BoolVar(true)},

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -150,7 +150,7 @@ var _ = Describe("GitHub Provider", func() {
 
 		var err error
 		c, err = NewClient(
-			WithPersonalAccessToken(githubToken),
+			WithOAuth2Token(githubToken),
 			WithDestructiveAPICalls(true),
 			WithConditionalRequests(true),
 			WithPreChainTransportHook(customTransportFactory),


### PR DESCRIPTION
PATs are oauth tokens so there's no reason to use BasicAuth here.

I read the GH docs as recommending `Authorization: Bearer` if possible.

GH understands what kind of token is being used, e.g. I see:
`Added on Aug 20, 2020 via personal access token owned by
@michaelbeaumont`
when I authenticate this way and add a DeployKey

I left the interface as is but `WithPersonalAccessToken` could also just be removed.