### PR TITLE
Change default branch in github integration tests to main

### DIFF
--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -42,7 +42,7 @@ const (
 
 	defaultDescription = "Foo description"
 	// TODO: This will change
-	defaultBranch = "master"
+	defaultBranch = "main"
 )
 
 var (


### PR DESCRIPTION
The default branch in newly created github repos has been renamed from `master` to `main`. This change corrects the validation of repos in github integration tests.
When the branch name changes in other providers the value in [gitprovider/types_repository.go](https://github.com/fluxcd/go-git-providers/blob/master/gitprovider/types_repository.go#L33) can be updated too as per the related comments.