### PR TITLE
make tests work for PR from fork

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        run: make test
+        run: |
+          [ -n "${{ secrets.GIT_PROVIDER_USER }}" ] && export GIT_PROVIDER_USER=${{ secrets.GIT_PROVIDER_USER }} || echo "using default GIT_PROVIDER_USER"
+          [ -n "${{ secrets.GIT_PROVIDER_ORGANIZATION }}" ] && export GIT_PROVIDER_ORGANIZATION=${{ secrets.GIT_PROVIDER_ORGANIZATION }} || echo "using default GIT_PROVIDER_ORGANIZATION"
+          [ -n "${{ secrets.GITLAB_USER }}" ] && export GITLAB_USER=${{ secrets.GITLAB_USER }} || echo "using default GITLAB_USER"
+          [ -n "${{ secrets.GITLAB_ORGANIZATION }}" ] && export GITLAB_ORGANIZATION=${{ secrets.GITLAB_ORGANIZATION }} || echo "using default GITLAB_ORGANIZATION"
+          [ -n "${{ secrets.GITLAB_TEAM_NAME }}" ] && export GITLAB_TEAM_NAME=${{ secrets.GITLAB_TEAM_NAME }} || echo "using default GITLAB_TEAM_NAME"
+          [ -n "${{ secrets.TEST_VERBOSE }}" ] && export TEST_VERBOSE=${{ secrets.TEST_VERBOSE }} || echo "TEST_VERBOSE not set"
+          make test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: build
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - master

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VER?=0.0.1
+TEST_VERBOSE?=
 
 all: test
 
@@ -12,7 +13,7 @@ vet:
 	go vet ./...
 
 test: tidy fmt vet
-	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test ${TEST_VERBOSE} -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 release:
 	git checkout master

--- a/github/example_organization_test.go
+++ b/github/example_organization_test.go
@@ -36,5 +36,5 @@ func ExampleOrganizationsClient_Get() {
 	internalOrg := org.APIObject().(*gogithub.Organization)
 
 	fmt.Printf("Name: %s. Location: %s.", *orgInfo.Name, internalOrg.GetLocation())
-	// Output: Name: Flux project. Location: CNCF sandbox.
+	// Output: Name: Flux project. Location: CNCF incubation.
 }

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -146,11 +146,11 @@ var _ = Describe("GitHub Provider", func() {
 			}
 		}
 
-		if orgName := os.Getenv("GIT_PROVIDER_ORGANIZATION"); len(orgName) != 0 {
+		if orgName := os.Getenv("GITHUB_ORGANIZATION"); len(orgName) != 0 {
 			testOrgName = orgName
 		}
 
-		if gitProviderUser := os.Getenv("GIT_PROVIDER_USER"); len(gitProviderUser) != 0 {
+		if gitProviderUser := os.Getenv("GITHUB_USER"); len(gitProviderUser) != 0 {
 			testUser = gitProviderUser
 		}
 

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -156,8 +157,16 @@ var _ = Describe("GitLab Provider", func() {
 			}
 		}
 
-		if orgName := os.Getenv("GIT_PROVIDER_ORGANIZATION"); len(orgName) != 0 {
+		if orgName := os.Getenv("GITLAB_ORGANIZATION"); len(orgName) != 0 {
 			testOrgName = orgName
+		}
+
+		if gitProviderUser := os.Getenv("GITLAB_USER"); len(gitProviderUser) != 0 {
+			testUserName = gitProviderUser
+		}
+
+		if teamName := os.Getenv("GITLAB_TEAM_NAME"); len(teamName) != 0 {
+			testTeamName = teamName
 		}
 
 		var err error
@@ -201,6 +210,40 @@ var _ = Describe("GitLab Provider", func() {
 		Expect(*info.Description).To(Equal(internal.Description))
 		Expect(string(*info.Visibility)).To(Equal(string(internal.Visibility)))
 		Expect(*info.DefaultBranch).To(Equal(internal.DefaultBranch))
+	}
+
+	cleanupOrgRepos := func(prefix string) {
+		fmt.Printf("Deleting repos starting with %s in org: %s\n", prefix, testOrgName)
+		repos, err := c.OrgRepositories().List(ctx, newOrgRef(testOrgName))
+		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			// Delete the test org repo used
+			name := repo.Repository().GetRepository()
+			if !strings.HasPrefix(name, prefix) {
+				fmt.Printf("Skipping the org repo: %s\n", name)
+				continue
+			}
+			fmt.Printf("Deleting the org repo: %s\n", name)
+			repo.Delete(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	cleanupUserRepos := func(prefix string) {
+		fmt.Printf("Deleting repos starting with %s for user: %s\n", prefix, testUserName)
+		repos, err := c.UserRepositories().List(ctx, newUserRef(testUserName))
+		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			// Delete the test org repo used
+			name := repo.Repository().GetRepository()
+			if !strings.HasPrefix(name, prefix) {
+				fmt.Printf("Skipping the org repo: %s\n", name)
+				continue
+			}
+			fmt.Printf("Deleting the org repo: %s\n", name)
+			repo.Delete(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
 	}
 
 	It("should list the available organizations the user has access to", func() {
@@ -360,6 +403,10 @@ var _ = Describe("GitLab Provider", func() {
 		// There should be 1 existing subgroup already
 		teams, err := testOrg.Teams().List(ctx)
 		Expect(err).ToNot(HaveOccurred())
+		fmt.Printf("Teams: %d, ...\n", len(teams))
+		for _, team := range teams {
+			fmt.Printf("Team: %s\n", team.Get().Name)
+		}
 		Expect(len(teams)).To(Equal(1), "The 1 team wasn't there...")
 
 		// First, check what repositories are available
@@ -528,6 +575,9 @@ var _ = Describe("GitLab Provider", func() {
 		// First, check what repositories are available
 		repos, err := c.UserRepositories().List(ctx, newUserRef(testUserName))
 		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			fmt.Printf("repo: %s\n", repo.Repository().GetRepository())
+		}
 
 		// Generate a repository name which doesn't exist already
 		testRepoName = fmt.Sprintf("test-repo-%03d", rand.Intn(1000))
@@ -630,6 +680,10 @@ var _ = Describe("GitLab Provider", func() {
 		if c == nil {
 			return
 		}
+
+		defer cleanupOrgRepos("test-org-repo")
+		defer cleanupUserRepos("test-repo")
+
 		// Delete the test repo used
 		fmt.Println("Deleting the user repo: ", testRepoName)
 		repoRef := newUserRepoRef(testUserName, testRepoName)

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -212,6 +212,37 @@ var _ = Describe("GitLab Provider", func() {
 		Expect(*info.DefaultBranch).To(Equal(internal.DefaultBranch))
 	}
 
+	cleanupOrgRepos := func(prefix string) {
+		fmt.Printf("Deleting repos starting with %s in org: %s\n", prefix, testOrgName)
+		repos, err := c.OrgRepositories().List(ctx, newOrgRef(testOrgName))
+		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			// Delete the test org repo used
+			name := repo.Repository().GetRepository()
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			fmt.Printf("Deleting the org repo: %s\n", name)
+			repo.Delete(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	cleanupUserRepos := func(prefix string) {
+		fmt.Printf("Deleting repos starting with %s for user: %s\n", prefix, testUserName)
+		repos, err := c.UserRepositories().List(ctx, newUserRef(testUserName))
+		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			// Delete the test org repo used
+			name := repo.Repository().GetRepository()
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			fmt.Printf("Deleting the org repo: %s\n", name)
+			repo.Delete(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
 	It("should list the available organizations the user has access to", func() {
 		// Get a list of all organizations the user is part of
 		orgs, err := c.Organizations().List(ctx)
@@ -642,6 +673,9 @@ var _ = Describe("GitLab Provider", func() {
 		if c == nil {
 			return
 		}
+
+		defer cleanupOrgRepos("test-org-repo")
+		defer cleanupUserRepos("test-repo")
 
 		// Delete the test repo used
 		fmt.Println("Deleting the user repo: ", testRepoName)

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -67,7 +66,6 @@ golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181108082009-03003ca0c849/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -80,7 +78,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -112,7 +109,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=


### PR DESCRIPTION
Update the GitLab example org test from sandbox to incubation, which
was missed from #69.

Add options to integration tests to allow tests to run against user's own
accounts and update build workflow to use fork rather than fluxcd
repository to run tests.

Signed-off-by: paulcarlton-ww <paul.carlton@weave.works>