### PR TITLE
Add util func for getting domain urls

### DIFF
--- a/gitlab/auth.go
+++ b/gitlab/auth.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/gitprovider/cache"
@@ -222,6 +223,13 @@ func NewClient(token string, tokenType string, optFns ...ClientOption) (gitprovi
 			}
 		} else {
 			domain = *opts.Domain
+			u, err := url.Parse(*opts.Domain)
+			if err != nil {
+				return nil, err
+			}
+			if u.Scheme == "" {
+				domain = fmt.Sprintf("https://%s", domain)
+			}
 			gl, err = gogitlab.NewOAuthClient(token, gogitlab.WithHTTPClient(httpClient), gogitlab.WithBaseURL(domain))
 			if err != nil {
 				return nil, err
@@ -237,6 +245,13 @@ func NewClient(token string, tokenType string, optFns ...ClientOption) (gitprovi
 			}
 		} else {
 			domain = *opts.Domain
+			u, err := url.Parse(*opts.Domain)
+			if err != nil {
+				return nil, err
+			}
+			if u.Scheme == "" {
+				domain = fmt.Sprintf("https://%s", domain)
+			}
 			gl, err = gogitlab.NewClient(token, gogitlab.WithHTTPClient(httpClient), gogitlab.WithBaseURL(domain))
 			if err != nil {
 				return nil, err

--- a/gitlab/auth.go
+++ b/gitlab/auth.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/gitprovider/cache"
@@ -223,13 +222,6 @@ func NewClient(token string, tokenType string, optFns ...ClientOption) (gitprovi
 			}
 		} else {
 			domain = *opts.Domain
-			u, err := url.Parse(*opts.Domain)
-			if err != nil {
-				return nil, err
-			}
-			if u.Scheme == "" {
-				domain = fmt.Sprintf("https://%s", domain)
-			}
 			gl, err = gogitlab.NewOAuthClient(token, gogitlab.WithHTTPClient(httpClient), gogitlab.WithBaseURL(domain))
 			if err != nil {
 				return nil, err
@@ -245,13 +237,6 @@ func NewClient(token string, tokenType string, optFns ...ClientOption) (gitprovi
 			}
 		} else {
 			domain = *opts.Domain
-			u, err := url.Parse(*opts.Domain)
-			if err != nil {
-				return nil, err
-			}
-			if u.Scheme == "" {
-				domain = fmt.Sprintf("https://%s", domain)
-			}
 			gl, err = gogitlab.NewClient(token, gogitlab.WithHTTPClient(httpClient), gogitlab.WithBaseURL(domain))
 			if err != nil {
 				return nil, err

--- a/gitlab/auth_test.go
+++ b/gitlab/auth_test.go
@@ -196,3 +196,48 @@ func Test_makeOptions(t *testing.T) {
 		})
 	}
 }
+
+func Test_DomainVariations(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         ClientOption
+		want         string
+		expectedErrs []error
+	}{
+		{
+			name: "gitlab.com domain",
+			opts: WithDomain("gitlab.com"),
+			want: "gitlab.com",
+		},
+		{
+			name: "custom domain without protocol",
+			opts: WithDomain("my-gitlab.dev.com"),
+			want: "https://my-gitlab.dev.com",
+		},
+		{
+			name: "custom domain with https protocol",
+			opts: WithDomain("my-gitlab.dev.com"),
+			want: "https://my-gitlab.dev.com",
+		},
+		{
+			name: "custom domain with http protocol",
+			opts: WithDomain("http://my-gitlab.dev.com"),
+			want: "http://my-gitlab.dev.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c1, _ := NewClient("token", "oauth2", tt.opts)
+			assertEqual(t, tt.want, c1.SupportedDomain())
+
+			c2, _ := NewClient("token", "pat", tt.opts)
+			assertEqual(t, tt.want, c2.SupportedDomain())
+		})
+	}
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	if a != b {
+		t.Fatalf("%s != %s", a, b)
+	}
+}

--- a/gitlab/auth_test.go
+++ b/gitlab/auth_test.go
@@ -207,7 +207,7 @@ func Test_DomainVariations(t *testing.T) {
 		{
 			name: "gitlab.com domain",
 			opts: WithDomain("gitlab.com"),
-			want: "gitlab.com",
+			want: "https://gitlab.com",
 		},
 		{
 			name: "custom domain without protocol",
@@ -216,7 +216,7 @@ func Test_DomainVariations(t *testing.T) {
 		},
 		{
 			name: "custom domain with https protocol",
-			opts: WithDomain("my-gitlab.dev.com"),
+			opts: WithDomain("https://my-gitlab.dev.com"),
 			want: "https://my-gitlab.dev.com",
 		},
 		{

--- a/gitlab/client.go
+++ b/gitlab/client.go
@@ -18,6 +18,8 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/xanzy/go-gitlab"
@@ -67,6 +69,10 @@ type Client struct {
 // what endpoints.
 // This field is set at client creation time, and can't be changed.
 func (c *Client) SupportedDomain() string {
+	u, _ := url.Parse(c.domain)
+	if u.Scheme == "" {
+		c.domain = fmt.Sprintf("https://%s", c.domain)
+	}
 	return c.domain
 }
 

--- a/gitprovider/repositoryref.go
+++ b/gitprovider/repositoryref.go
@@ -55,7 +55,7 @@ type IdentityRef interface {
 	// IdentityTypeSuborganization are returned, this IdentityRef can be casted to a OrganizationRef.
 	GetType() IdentityType
 
-	// String returns the HTTPS URL, and implements fmt.Stringer.
+	// String returns the URL, and implements fmt.Stringer.
 	String() string
 }
 
@@ -103,7 +103,8 @@ func (u UserRef) GetType() IdentityType {
 
 // String returns the HTTPS URL to access the User.
 func (u UserRef) String() string {
-	return fmt.Sprintf("https://%s/%s", u.GetDomain(), u.GetIdentity())
+	domain := GetDomainURL(u.GetDomain())
+	return fmt.Sprintf("%s/%s", domain, u.GetIdentity())
 }
 
 // ValidateFields validates its own fields for a given validator.
@@ -157,9 +158,10 @@ func (o OrganizationRef) GetType() IdentityType {
 	return IdentityTypeOrganization
 }
 
-// String returns the HTTPS URL to access the Organization.
+// String returns the URL to access the Organization.
 func (o OrganizationRef) String() string {
-	return fmt.Sprintf("https://%s/%s", o.GetDomain(), o.GetIdentity())
+	domain := GetDomainURL(o.GetDomain())
+	return fmt.Sprintf("%s/%s", domain, o.GetIdentity())
 }
 
 // ValidateFields validates its own fields for a given validator.
@@ -220,7 +222,7 @@ type UserRepositoryRef struct {
 	RepositoryName string `json:"repositoryName"`
 }
 
-// String returns the HTTPS URL to access the repository.
+// String returns the URL to access the repository.
 func (r UserRepositoryRef) String() string {
 	return fmt.Sprintf("%s/%s", r.UserRef.String(), r.RepositoryName)
 }

--- a/gitprovider/repositoryref_test.go
+++ b/gitprovider/repositoryref_test.go
@@ -660,3 +660,70 @@ func TestRepositoryRef_ValidateFields(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDomainURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		want   string
+	}{
+		{
+			name:   "github.com, no https",
+			domain: "github.com",
+			want:   "https://github.com",
+		},
+		{
+			name:   "github.com, with https",
+			domain: "https://github.com",
+			want:   "https://github.com",
+		},
+		{
+			name:   "github enterprise, no https",
+			domain: "my-github.com",
+			want:   "https://my-github.com",
+		},
+		{
+			name:   "github enterprise, with http",
+			domain: "http://my-github.com",
+			want:   "http://my-github.com",
+		},
+		{
+			name:   "github enterprise, with https",
+			domain: "https://my-github.com",
+			want:   "https://my-github.com",
+		},
+		{
+			name:   "gitlab.com, no https",
+			domain: "gitlab.com",
+			want:   "https://gitlab.com",
+		},
+		{
+			name:   "gitlab.com, with https",
+			domain: "https://gitlab.com",
+			want:   "https://gitlab.com",
+		},
+		{
+			name:   "self hosted gitlab, no https",
+			domain: "my-gitlab.com",
+			want:   "https://my-gitlab.com",
+		},
+		{
+			name:   "self hosted gitlab, with https",
+			domain: "https://my-gitlab.com",
+			want:   "https://my-gitlab.com",
+		},
+		{
+			name:   "self hosted gitlab, with http",
+			domain: "http://my-gitlab.com",
+			want:   "http://my-gitlab.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetDomainURL(tt.domain)
+			if got != tt.want {
+				t.Errorf("GetDomainURL(domain) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gitprovider/util.go
+++ b/gitprovider/util.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package gitprovider
 
+import (
+	"fmt"
+	"net/url"
+)
+
 // BoolVar returns a pointer to the given bool.
 func BoolVar(b bool) *bool {
 	return &b
@@ -24,4 +29,13 @@ func BoolVar(b bool) *bool {
 // StringVar returns a pointer to the given string.
 func StringVar(s string) *string {
 	return &s
+}
+
+// GetDomainURL returns the domain URL prepended with https:// if a scheme is not set.
+func GetDomainURL(d string) string {
+	parsedURL, _ := url.Parse(d)
+	if parsedURL.Scheme == "" {
+		d = fmt.Sprintf("https://%s", d)
+	}
+	return d
 }


### PR DESCRIPTION
Adds utility function `GetDomainURL` to set the URL scheme of a domain to `https://`, if it is not specified. 

Closes #55