### PR TITLE
Check url scheme matches http or https

### DIFF
--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -529,7 +529,7 @@ var _ = Describe("GitLab Provider", func() {
 		readOnly := false
 		testDeployKeyInfo := gitprovider.DeployKeyInfo{
 			Name:     testDeployKeyName,
-			Key:      []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLbHBknQQaasdl2/O9DfgizMyUh/lhYwXk9GrBY9Ow9fFHy+lIiRBiS8H4rjvP2YkECrWWSbcevTKe+yk7PsU98RZiPL9S2+d2ENo3uQ2Rp6xnKY+XtvJnSvpLnABz/mGDPgvcLxXvPj2rAGu35u08DZ1WufU7hzgiWuLM3TH/albVcadw5ZflOAXalMmUhinB9m/O71DWyaP33pIqZBGCc8IBMcUHOL72NkNcpatXvCALltApJVUPZIvQUnrmUOglQMklaCeeWn6B269UI9kH9TjhGbbIvHpPZ7Ky9RTklZTeINLZW5Yql/leA/vJGcIipyXQkDPs7RSwtpmp5kat dinos@dinos-desktop"),
+			Key:      []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8f94nlLYm+pFUCE0BSpNGrcGtxVbqNcsrg54wzbbazHadP4JpMQzjGjIJZI9q+gK+nCiU6KqDsm55fyPb8dkDjXcp/3soYlBS9fLkuh0v2LlLfM9AnqShQVM1CKFs8VzDEnwMfhIx3XR1JJJfGEyu36GzAgHv3bSGYMi5MyPT16yCg9427RwaokV1+9MTXdjCS1OOrhMqCwgHcHhBCdY/st9k2l1OLXW40IJ4fHT9QTyGQvp4UZE6xylJxJdJEnK/YDloW1HpL+U63lxUl+ME8abmpFdenBiysC/FBhKb7b6rmnxSbw9DbAVdXaB9knJ21EjdEWtRV75wVfONwUFL user@host"),
 			ReadOnly: &readOnly,
 		}
 		_, err = orgRepo.DeployKeys().Create(ctx, testDeployKeyInfo)
@@ -556,7 +556,7 @@ var _ = Describe("GitLab Provider", func() {
 		title := "new-title"
 		req := getKey.Get()
 		req.Name = title
-		req.Key = []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCasdHV91pRmqTaWPJnvZmvTPZPpHmIYocY1kmYFeOOL6/ofdvYb1sxNwsccOJEeLGJjp6FGe4BWNQSqDUCeO3EVU8A7ZTnd9eizB8nYDGoACbmG2GfMmtAdxKfsPE/lNRzAOFmHAHrzOnL6zk5SMPe0Y2poW1Z5w+If5r62WwfqG2/ujUA7BU3Vf/arFIYJvXvuEOJMP3QbezWL0b22Wmedu8esKrOYcak80I6Ti8qiof8ly1JZa58ezHJVvcEWZGSKU4G53jmDz7ky4GGb9DRo+LqOaU1qetdJX1GiCRNnhvz8DsxGcL77BJPE7HPBct44lN1TZCeIOG00Hai4bDp dinos@dinos-desktop")
+		req.Key = []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVkrF2RW7z8kG6K530zOCiVdGBfYErh+cYch1d48/ZpPYd45h9oG6E6qtkc6WD9/6WOV3RWNqeePTnxPfD2oEr6Lzh1lPazBmcWFvexct0q3+9XbR4Ir0h43gjjxtzyeaDHpKNFpupKDOA+iVTuewOARpqqaHpASW8PQrCCaCG/g9p8dK7vLKJXegEY+TIXJFLM5PWRR2SJZCsifyJytDeKxcUw9lGCXi/Bq5ce+xpZIUpv8TXmB5MYwNZSM5eEQcpsG2/obKWC0iN73PoC5IH0UaAiVrJzLbg2U8SZJGZOSPNu/KQugiXmJHRkgmu1J6TfyqRRccru+RpxFEbvC1d user@node")
 		Expect(getKey.Set(req)).ToNot(HaveOccurred())
 		actionTaken, err = getKey.Reconcile(ctx)
 		// Expect the update to succeed, and modify the state

--- a/gitprovider/util.go
+++ b/gitprovider/util.go
@@ -34,7 +34,7 @@ func StringVar(s string) *string {
 // GetDomainURL returns the domain URL prepended with https:// if a scheme is not set.
 func GetDomainURL(d string) string {
 	parsedURL, _ := url.Parse(d)
-	if parsedURL.Scheme == "" {
+	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
 		d = fmt.Sprintf("https://%s", d)
 	}
 	return d


### PR DESCRIPTION
### Description

The scheme of custom gitlab urls is parsed incorrectly in `GetDomainURL` util.
This checks specifically if it matches `http` or `https`.

### Test results
```
*Gitlab*
Running Suite: GitLab Provider Suite
====================================
Random Seed: 1619706988
Will run 11 of 11 specs

GitLab Provider 
  should list the available organizations the user has access to
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:258
[It] should list the available organizations the user has access to
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:258
•
------------------------------
GitLab Provider 
  should not fail when .Children is called
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:307
[It] should not fail when .Children is called
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:307
•
------------------------------
GitLab Provider 
  should be possible to create a group project
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:315
[It] should be possible to create a group project
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:315
•
------------------------------
GitLab Provider 
  should error at creation time if the org repo already does exist
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:355
[It] should error at creation time if the org repo already does exist
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:355
•
------------------------------
GitLab Provider 
  should update if the org repo already exists when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:361
[It] should update if the org repo already exists when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:361
•
------------------------------
GitLab Provider 
  should update teams with access and permissions when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:404
[It] should update teams with access and permissions when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:404

• [SLOW TEST:15.356 seconds]
GitLab Provider
/home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:171
  should update teams with access and permissions when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:404
------------------------------
GitLab Provider 
  should create, delete and reconcile deploy keys
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:517
[It] should create, delete and reconcile deploy keys
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:517
•
------------------------------
GitLab Provider 
  should be possible to create a user project
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:579
[It] should be possible to create a user project
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:579
•
------------------------------
GitLab Provider 
  should error at creation time if the user repo already does exist
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:626
[It] should error at creation time if the user repo already does exist
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:626
•
------------------------------
GitLab Provider 
  should update if the user repo already exists when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:632
[It] should update if the user repo already exists when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:632

• [SLOW TEST:5.778 seconds]
GitLab Provider
/home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:171
  should update if the user repo already exists when reconciling
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:632
------------------------------
GitLab Provider 
  should be possible to create a pr for a user repository
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:675
[It] should be possible to create a pr for a user repository
  /home/dinos/go/src/github.com/weaveworks/go-git-providers/gitlab/integration_test.go:675
•Deleting the user repo:  test-repo2-138
Deleting the org repo:  test-org-repo-273
Deleting the shared org repo:  test-shared-org-repo-878

Ran 11 of 11 Specs in 46.986 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
Name: fluxcd-testing-public. Location: fluxcd-testing-public.PASS

Ginkgo ran 1 suite in 48.740979597s
Test Suite Passed

*make test output*
➜  go-git-providers git:(fix/check-url-scheme) ✗ make test
go mod tidy
go fmt ./...
go vet ./...
go test -race -coverprofile=coverage.txt -covermode=atomic ./...
?   	github.com/fluxcd/go-git-providers/bitbucket	[no test files]
ok  	github.com/fluxcd/go-git-providers/github	12.488s	coverage: 50.4% of statements
ok  	github.com/fluxcd/go-git-providers/gitlab	46.016s	coverage: 73.9% of statements
ok  	github.com/fluxcd/go-git-providers/gitprovider	0.038s	coverage: 94.5% of statements
?   	github.com/fluxcd/go-git-providers/gitprovider/cache	[no test files]
?   	github.com/fluxcd/go-git-providers/gitprovider/testutils	[no test files]
ok  	github.com/fluxcd/go-git-providers/validation	0.028s	coverage: 100.0% of statements
```
