### PR TITLE
Generates deploy keys in each integration test run

### DIFF
--- a/gitprovider/testutils/key_pair.go
+++ b/gitprovider/testutils/key_pair.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// KeyPair holds the public and private key PEM block bytes.
+type KeyPair struct {
+	PublicKey  []byte
+	PrivateKey []byte
+}
+
+type KeyPairGenerator interface {
+	Generate() (*KeyPair, error)
+}
+
+type RSAGenerator struct {
+	bits int
+}
+
+func NewRSAGenerator(bits int) KeyPairGenerator {
+	return &RSAGenerator{bits}
+}
+
+func (g *RSAGenerator) Generate() (*KeyPair, error) {
+	pk, err := rsa.GenerateKey(rand.Reader, g.bits)
+	if err != nil {
+		return nil, err
+	}
+	err = pk.Validate()
+	if err != nil {
+		return nil, err
+	}
+	pub, err := generatePublicKey(&pk.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	priv, err := encodePrivateKeyToPEM(pk)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPair{
+		PublicKey:  pub,
+		PrivateKey: priv,
+	}, nil
+}
+
+type ECDSAGenerator struct {
+	c elliptic.Curve
+}
+
+func NewECDSAGenerator(c elliptic.Curve) KeyPairGenerator {
+	return &ECDSAGenerator{c}
+}
+
+func (g *ECDSAGenerator) Generate() (*KeyPair, error) {
+	pk, err := ecdsa.GenerateKey(g.c, rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	pub, err := generatePublicKey(&pk.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	priv, err := encodePrivateKeyToPEM(pk)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPair{
+		PublicKey:  pub,
+		PrivateKey: priv,
+	}, nil
+}
+
+type Ed25519Generator struct{}
+
+func NewEd25519Generator() KeyPairGenerator {
+	return &Ed25519Generator{}
+}
+
+func (g *Ed25519Generator) Generate() (*KeyPair, error) {
+	pk, pv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	pub, err := generatePublicKey(pk)
+	if err != nil {
+		return nil, err
+	}
+	priv, err := encodePrivateKeyToPEM(pv)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPair{
+		PublicKey:  pub,
+		PrivateKey: priv,
+	}, nil
+}
+
+func generatePublicKey(pk interface{}) ([]byte, error) {
+	b, err := ssh.NewPublicKey(pk)
+	if err != nil {
+		return nil, err
+	}
+	k := ssh.MarshalAuthorizedKey(b)
+	return k, nil
+}
+
+// encodePrivateKeyToPEM encodes the given private key to a PEM block.
+// The encoded format is PKCS#8 for universal support of the most
+// common key types (rsa, ecdsa, ed25519).
+func encodePrivateKeyToPEM(pk interface{}) ([]byte, error) {
+	b, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		return nil, err
+	}
+	block := pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: b,
+	}
+	return pem.EncodeToMemory(&block), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/xanzy/go-gitlab v0.33.0
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288
 )


### PR DESCRIPTION
### Description

Copies `key_pair.go` from https://github.com/fluxcd/pkg/blob/main/ssh/key_pair.go to `gitprovider/testutils` to generate deploy keys in each integration test run, replacing hardcoded values.

### Test results

```
➜  go-git-providers git:(generate-deploy-keys-in-tests) make test
go mod tidy
go fmt ./...
go vet ./...
go test -race -coverprofile=coverage.txt -covermode=atomic ./...
?   	github.com/fluxcd/go-git-providers/bitbucket	[no test files]
ok  	github.com/fluxcd/go-git-providers/github	13.853s	coverage: 50.4% of statements
ok  	github.com/fluxcd/go-git-providers/gitlab	44.154s	coverage: 74.0% of statements
ok  	github.com/fluxcd/go-git-providers/gitprovider	0.038s	coverage: 94.5% of statements
?   	github.com/fluxcd/go-git-providers/gitprovider/cache	[no test files]
?   	github.com/fluxcd/go-git-providers/gitprovider/testutils	[no test files]
ok  	github.com/fluxcd/go-git-providers/validation	0.035s	coverage: 100.0% of statements
...
Ran 11 of 11 Specs in 47.381 seconds
 SUCCESS! -- 11 Passed 0 Failed 0 Pending 0 Skipped
Name: fluxcd-testing-public. Location: fluxcd-testing-public.PASS
```