### PR TITLE
Updated gitlab dependency to v0.43.0

### DIFF
--- a/gitlab/client_repository_commit.go
+++ b/gitlab/client_repository_commit.go
@@ -70,12 +70,16 @@ func (c *CommitClient) Create(ctx context.Context, branch string, message string
 		return nil, fmt.Errorf("no files added")
 	}
 
-	commitActions := make([]*gitlab.CommitAction, 0)
+	fileAction := gitlab.FileCreate
+
+	commitActions := make([]*gitlab.CommitActionOptions, 0)
 	for _, file := range files {
-		commitActions = append(commitActions, &gitlab.CommitAction{
-			Action:   gitlab.FileCreate,
-			FilePath: *file.Path,
-			Content:  *file.Content,
+		filePath := *file.Path
+		fileContent := *file.Content
+		commitActions = append(commitActions, &gitlab.CommitActionOptions{
+			Action:   &fileAction,
+			FilePath: &filePath,
+			Content:  &fileContent,
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ktrysmt/go-bitbucket v0.6.2
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/xanzy/go-gitlab v0.33.0
+	github.com/xanzy/go-gitlab v0.43.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288
 )

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/xanzy/go-gitlab v0.33.0 h1:MUJZknbLhVXSFzBA5eqGGhQ2yHSu8tPbGBPeB3sN4B0=
-github.com/xanzy/go-gitlab v0.33.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.43.0 h1:rpOZQjxVJGW/ch+Jy4j7W4o7BB1mxkXJNVGuplZ7PUs=
+github.com/xanzy/go-gitlab v0.43.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
### Description

Updated gitlab dependency to v0.43.0


### Test results

```
=== RUN   Test_clientOptions_getTransportChain
--- PASS: Test_clientOptions_getTransportChain (0.00s)
=== RUN   Test_clientOptions_getTransportChain/all_roundtrippers
    --- PASS: Test_clientOptions_getTransportChain/all_roundtrippers (0.00s)
=== RUN   Test_clientOptions_getTransportChain/only_pre_+_auth
    --- PASS: Test_clientOptions_getTransportChain/only_pre_+_auth (0.00s)
=== RUN   Test_clientOptions_getTransportChain/only_cache_+_auth
    --- PASS: Test_clientOptions_getTransportChain/only_cache_+_auth (0.00s)
=== RUN   Test_makeOptions
--- PASS: Test_makeOptions (0.00s)
=== RUN   Test_makeOptions/no_options
    --- PASS: Test_makeOptions/no_options (0.00s)
=== RUN   Test_makeOptions/WithDomain
    --- PASS: Test_makeOptions/WithDomain (0.00s)
=== RUN   Test_makeOptions/WithDomain,_empty
    --- PASS: Test_makeOptions/WithDomain,_empty (0.00s)
=== RUN   Test_makeOptions/WithDestructiveAPICalls
    --- PASS: Test_makeOptions/WithDestructiveAPICalls (0.00s)
=== RUN   Test_makeOptions/WithPreChainTransportHook
    --- PASS: Test_makeOptions/WithPreChainTransportHook (0.00s)
=== RUN   Test_makeOptions/WithPreChainTransportHook,_nil
    --- PASS: Test_makeOptions/WithPreChainTransportHook,_nil (0.00s)
=== RUN   Test_makeOptions/WithPostChainTransportHook
    --- PASS: Test_makeOptions/WithPostChainTransportHook (0.00s)
=== RUN   Test_makeOptions/WithPostChainTransportHook,_nil
    --- PASS: Test_makeOptions/WithPostChainTransportHook,_nil (0.00s)
=== RUN   Test_makeOptions/WithOAuth2Token
    --- PASS: Test_makeOptions/WithOAuth2Token (0.00s)
=== RUN   Test_makeOptions/WithOAuth2Token,_empty
    --- PASS: Test_makeOptions/WithOAuth2Token,_empty (0.00s)
=== RUN   Test_makeOptions/WithConditionalRequests
    --- PASS: Test_makeOptions/WithConditionalRequests (0.00s)
=== RUN   Test_makeOptions/WithConditionalRequests,_exclusive
    --- PASS: Test_makeOptions/WithConditionalRequests,_exclusive (0.00s)
=== RUN   Test_DomainVariations
--- PASS: Test_DomainVariations (0.00s)
=== RUN   Test_DomainVariations/gitlab.com_domain
    --- PASS: Test_DomainVariations/gitlab.com_domain (0.00s)
=== RUN   Test_DomainVariations/custom_domain_without_protocol
    --- PASS: Test_DomainVariations/custom_domain_without_protocol (0.00s)
=== RUN   Test_DomainVariations/custom_domain_with_https_protocol
    --- PASS: Test_DomainVariations/custom_domain_with_https_protocol (0.00s)
=== RUN   Test_DomainVariations/custom_domain_with_http_protocol
    --- PASS: Test_DomainVariations/custom_domain_with_http_protocol (0.00s)
=== RUN   TestProvider
Running Suite: GitLab Provider Suite
====================================
Random Seed: 1620250511
Will run 11 of 11 specs

• [SLOW TEST:9.595 seconds]
GitLab Provider
/Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:172
  should list the available organizations the user has access to
  /Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:259
------------------------------
•
------------------------------
• [SLOW TEST:12.490 seconds]
GitLab Provider
/Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:172
  should be possible to create a group project
  /Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:316
------------------------------
•
------------------------------
• [SLOW TEST:6.063 seconds]
GitLab Provider
/Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:172
  should update if the org repo already exists when reconciling
  /Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:362
------------------------------
• [SLOW TEST:72.146 seconds]
GitLab Provider
/Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:172
  should update teams with access and permissions when reconciling
  /Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:405
------------------------------
•
------------------------------
• [SLOW TEST:15.968 seconds]
GitLab Provider
/Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:172
  should be possible to create a user project
  /Users/joseordaz/go/src/github.com/josecordaz/go-git-providers/gitlab/integration_test.go:591
------------------------------
•••Deleting the user repo:  test-repo2-304
Deleting the org repo:  test-org-repo-402
Deleting the shared org repo:  test-shared-org-repo-643

Ran 11 of 11 Specs in 132.098 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestProvider (132.10s)
=== RUN   Test_getGitProviderPermission
--- PASS: Test_getGitProviderPermission (0.00s)
=== RUN   Test_getGitProviderPermission/pull
    --- PASS: Test_getGitProviderPermission/pull (0.00s)
=== RUN   Test_getGitProviderPermission/push
    --- PASS: Test_getGitProviderPermission/push (0.00s)
=== RUN   Test_getGitProviderPermission/admin
    --- PASS: Test_getGitProviderPermission/admin (0.00s)
=== RUN   Test_getGitProviderPermission/false_data
    --- PASS: Test_getGitProviderPermission/false_data (0.00s)
=== RUN   Test_getGitlabPermission
--- PASS: Test_getGitlabPermission (0.00s)
=== RUN   Test_getGitlabPermission/pull
    --- PASS: Test_getGitlabPermission/pull (0.00s)
=== RUN   Test_getGitlabPermission/push
    --- PASS: Test_getGitlabPermission/push (0.00s)
=== RUN   Test_getGitlabPermission/admin
    --- PASS: Test_getGitlabPermission/admin (0.00s)
=== RUN   Test_validateAPIObject
--- PASS: Test_validateAPIObject (0.00s)
=== RUN   Test_validateAPIObject/no_error_=>_nil
    --- PASS: Test_validateAPIObject/no_error_=>_nil (0.00s)
=== RUN   Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData
    --- PASS: Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData (0.00s)
=== RUN   Test_allGroupPages
--- PASS: Test_allGroupPages (0.00s)
=== RUN   Test_allGroupPages/one_page_only,_no_error
    --- PASS: Test_allGroupPages/one_page_only,_no_error (0.00s)
=== RUN   Test_allGroupPages/two_pages,_no_error
    --- PASS: Test_allGroupPages/two_pages,_no_error (0.00s)
=== RUN   Test_allGroupPages/four_pages,_error_at_second
    --- PASS: Test_allGroupPages/four_pages,_error_at_second (0.00s)
=== RUN   TestExampleOrganizationsClient_Get
Name: fluxcd-testing-public. Location: fluxcd-testing-public.--- PASS: TestExampleOrganizationsClient_Get (0.43s)
PASS

Process finished with the exit code 0
=== RUN   ExampleOrgRepositoriesClient_Get
--- PASS: ExampleOrgRepositoriesClient_Get (0.53s)
```
