### PR TITLE
Return WebURL of newly created pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ See the following (automatically tested) examples:
 - [github/example_organization_test.go](github/example_organization_test.go)
 - [github/example_repository_test.go](github/example_repository_test.go)
 
+
+If you need to run `make test` for your fork/branch you may need to supply the following environment variables:
+- GIT_PROVIDER_ORGANIZATION : For GitHub this should be an organization whereas for GitLab this should be a top-level group. As this environment variable is used for both test suites, the name of the GitHub organization must match the name of the GitLab top-level group. Also, this organization needs to have its repository default branch set to `main`.
+- GIT_PROVIDER_USER : This should be the same username for both GitHub and GitLab.
+- GITLAB_TEST_TEAM_NAME : An existing GitLab group.
+- GITLAB_TEST_SUBGROUP : An existing GitLab subgroup of the GIT_PROVIDER_ORGANIZATION top-level group.
+- GITHUB_TOKEN : A GitHub token with `repo`, `admin:org` and `delete_repo` permissions.
+- GITLAB_TOKEN: A GitLab token with `api` scope.
+
 ## Maintainers
 
 In alphabetical order:
@@ -181,6 +190,7 @@ In alphabetical order:
 - Simon Howe, [@foot](https://github.com/foot)
 - Dinos Kousidis, [@dinosk](https://github.com/dinosk)
 - Stefan Prodan, [@stefanprodan](https://github.com/stefanprodan)
+- Yiannis Triantafyllopoulos, [@yiannistri](https://github.com/yiannistri)
 
 ## Getting Help
 

--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -18,6 +18,7 @@ package github
 
 import (
 	"context"
+
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/google/go-github/v32/github"
 )
@@ -32,7 +33,7 @@ type PullRequestClient struct {
 }
 
 // Create creates a pull request with the given specifications.
-func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranch, description string) error {
+func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranch, description string) (gitprovider.PullRequest, error) {
 
 	prOpts := &github.NewPullRequest{
 		Title: &title,
@@ -41,9 +42,10 @@ func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranc
 		Body:  &description,
 	}
 
-	if _, _, err := c.c.Client().PullRequests.Create(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), prOpts); err != nil {
-		return err
+	pr, _, err := c.c.Client().PullRequests.Create(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), prOpts)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return newPullRequest(c.clientContext, pr), nil
 }

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -408,9 +408,9 @@ var _ = Describe("GitHub Provider", func() {
 		_, err = userRepo.Commits().Create(ctx, branchName, "added config file", files)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = userRepo.PullRequests().Create(ctx, "Added config file", branchName, *defaultBranch, "added config file")
+		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, *defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
-
+		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 	})
 
 	AfterSuite(func() {

--- a/github/resource_pullrequest.go
+++ b/github/resource_pullrequest.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/google/go-github/v32/github"
+)
+
+func newPullRequest(ctx *clientContext, apiObj *github.PullRequest) *pullrequest {
+	return &pullrequest{
+		clientContext: ctx,
+		pr:            *apiObj,
+	}
+}
+
+var _ gitprovider.PullRequest = &pullrequest{}
+
+type pullrequest struct {
+	*clientContext
+
+	pr github.PullRequest
+}
+
+func (pr *pullrequest) Get() gitprovider.PullRequestInfo {
+	return pullrequestFromAPI(&pr.pr)
+}
+
+func (pr *pullrequest) APIObject() interface{} {
+	return &pr.pr
+}
+
+func pullrequestFromAPI(apiObj *github.PullRequest) gitprovider.PullRequestInfo {
+	return gitprovider.PullRequestInfo{
+		WebURL: apiObj.GetHTMLURL(),
+	}
+}

--- a/gitlab/client_repository_pullrequest.go
+++ b/gitlab/client_repository_pullrequest.go
@@ -18,6 +18,7 @@ package gitlab
 
 import (
 	"context"
+
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/xanzy/go-gitlab"
 )
@@ -32,7 +33,7 @@ type PullRequestClient struct {
 }
 
 // Create creates a pull request with the given specifications.
-func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranch, description string) error {
+func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranch, description string) (gitprovider.PullRequest, error) {
 
 	prOpts := &gitlab.CreateMergeRequestOptions{
 		Title:        &title,
@@ -41,9 +42,10 @@ func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranc
 		Description:  &description,
 	}
 
-	if _, _, err := c.c.Client().MergeRequests.CreateMergeRequest(getRepoPath(c.ref), prOpts); err != nil {
-		return err
+	mr, _, err := c.c.Client().MergeRequests.CreateMergeRequest(getRepoPath(c.ref), prOpts)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return newPullRequest(c.clientContext, mr), nil
 }

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -729,9 +729,9 @@ var _ = Describe("GitLab Provider", func() {
 		_, err = userRepo.Commits().Create(ctx, branchName, "added config file", files)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = userRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
+		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
-
+		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 	})
 
 	AfterSuite(func() {

--- a/gitlab/resource_pullrequest.go
+++ b/gitlab/resource_pullrequest.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+import (
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/xanzy/go-gitlab"
+)
+
+func newPullRequest(ctx *clientContext, apiObj *gitlab.MergeRequest) *pullrequest {
+	return &pullrequest{
+		clientContext: ctx,
+		pr:            *apiObj,
+	}
+}
+
+var _ gitprovider.PullRequest = &pullrequest{}
+
+type pullrequest struct {
+	*clientContext
+
+	pr gitlab.MergeRequest
+}
+
+func (pr *pullrequest) Get() gitprovider.PullRequestInfo {
+	return pullrequestFromAPI(&pr.pr)
+}
+
+func (pr *pullrequest) APIObject() interface{} {
+	return &pr.pr
+}
+
+func pullrequestFromAPI(apiObj *gitlab.MergeRequest) gitprovider.PullRequestInfo {
+	return gitprovider.PullRequestInfo{
+		WebURL: apiObj.WebURL,
+	}
+}

--- a/gitprovider/client.go
+++ b/gitprovider/client.go
@@ -228,5 +228,5 @@ type BranchClient interface {
 // This client can be accessed through Repository.PullRequests().
 type PullRequestClient interface {
 	// Create creates a pull request with the given specifications.
-	Create(ctx context.Context, title, branch, baseBranch, description string) error
+	Create(ctx context.Context, title, branch, baseBranch, description string) (PullRequest, error)
 }

--- a/gitprovider/resources.go
+++ b/gitprovider/resources.go
@@ -138,3 +138,12 @@ type Commit interface {
 	// Get returns high-level information about this commit.
 	Get() CommitInfo
 }
+
+type PullRequest interface {
+	// Object implements the Object interface,
+	// allowing access to the underlying object returned from the API.
+	Object
+
+	// Get returns high-level information about this pull request.
+	Get() PullRequestInfo
+}

--- a/gitprovider/types_repository.go
+++ b/gitprovider/types_repository.go
@@ -199,3 +199,9 @@ type CommitFile struct {
 	// +required
 	Content *string `json:"content"`
 }
+
+type PullRequestInfo struct {
+	// WebURL is the URL of the pull request in the git provider web interface.
+	// +required
+	WebURL string `json:"web_url"`
+}


### PR DESCRIPTION
### Description

- Introduced a PullRequest interface that can be used to get information about a pull request.
- Implemented interface for both GitHub and GitLab providers
- Currently it returns the (web) URL of the newly created pull request
- Updated README to document environment variables used during test runs
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
-->


### Test results
```bash
➜ make test
go mod tidy
go fmt ./...
go vet ./...
go test -race -coverprofile=coverage.txt -covermode=atomic ./...
?   	github.com/fluxcd/go-git-providers/bitbucket	[no test files]
ok  	github.com/fluxcd/go-git-providers/github	14.856s	coverage: 50.8% of statements
ok  	github.com/fluxcd/go-git-providers/gitlab	46.675s	coverage: 73.9% of statements
ok  	github.com/fluxcd/go-git-providers/gitprovider	0.170s	coverage: 94.5% of statements
?   	github.com/fluxcd/go-git-providers/gitprovider/cache	[no test files]
?   	github.com/fluxcd/go-git-providers/gitprovider/testutils	[no test files]
ok  	github.com/fluxcd/go-git-providers/validation	0.149s	coverage: 100.0% of statements
```
<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
