### PR TITLE
Support running tests in forked repository workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,11 +24,18 @@ jobs:
         with:
           go-version: 1.15.x
       - name: Run tests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
-          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        run: make test
+        run: |
+          [ -n "${{ secrets.GITLAB_TOKEN }}" ] && export GITLAB_TOKEN=${{ secrets.GITLAB_TOKEN }} || echo "using default GITLAB_TOKEN"
+          [ -n "${{ secrets.GITPROVIDER_BOT_TOKEN }}" ] && export GITHUB_TOKEN=${{ secrets.GITPROVIDER_BOT_TOKEN }} || echo "using default GITHUB_TOKEN"
+          [ -n "${{ secrets.GIT_PROVIDER_USER }}" ] && export GIT_PROVIDER_USER=${{ secrets.GIT_PROVIDER_USER }} || echo "using default GIT_PROVIDER_USER"
+          [ -n "${{ secrets.GIT_PROVIDER_ORGANIZATION }}" ] && export GIT_PROVIDER_ORGANIZATION=${{ secrets.GIT_PROVIDER_ORGANIZATION }} || echo "using default GIT_PROVIDER_ORGANIZATION"
+          [ -n "${{ secrets.GITLAB_TEST_TEAM_NAME }}" ] && export GITLAB_TEST_TEAM_NAME=${{ secrets.GITLAB_TEST_TEAM_NAME }} || echo "using default GITLAB_TEST_TEAM_NAME"
+          [ -n "${{ secrets.GITLAB_TEST_SUBGROUP }}" ] && export GITLAB_TEST_SUBGROUP=${{ secrets.GITLAB_TEST_SUBGROUP }} || echo "using default GITLAB_TEST_SUBGROUP"
+          [ -n "${{ secrets.TEST_VERBOSE }}" ] && export TEST_VERBOSE=${{ secrets.TEST_VERBOSE }} || echo "TEST_VERBOSE not set"
+          [ -n "${{ secrets.CLEANUP_ALL }}" ] && export CLEANUP_ALL=${{ secrets.CLEANUP_ALL }} || echo "CLEANUP_ALL not set"
+          make test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.txt
+

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -32,4 +32,4 @@ jobs:
           version: latest
           args: release --release-notes=/tmp/release.txt --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARD
 To run the e2e tests you'll have to provide GitHub and GitLab tokens:
 
 ```sh
-export GITHUB_TOKEN=YOUR-GH-ADMIN-TOKEN
+export GITPROVIDER_BOT_TOKEN=YOUR-GH-ADMIN-TOKEN
 export GITLAB_TOKEN=YOUR-GL-ADMIN-TOKEN
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VER?=0.0.1
+TEST_VERBOSE?=
 
 all: test
 
@@ -12,7 +13,7 @@ vet:
 	go vet ./...
 
 test: tidy fmt vet
-	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test ${TEST_VERBOSE} -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 release:
 	git checkout main

--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ If you need to run `make test` for your fork/branch you may need to supply the f
 - GIT_PROVIDER_USER : This should be the same username for both GitHub and GitLab.
 - GITLAB_TEST_TEAM_NAME : An existing GitLab group.
 - GITLAB_TEST_SUBGROUP : An existing GitLab subgroup of the GIT_PROVIDER_ORGANIZATION top-level group.
-- GITHUB_TOKEN : A GitHub token with `repo`, `admin:org` and `delete_repo` permissions.
+- GITPROVIDER_BOT_TOKEN : A GitHub token with `repo`, `admin:org` and `delete_repo` permissions.
 - GITLAB_TOKEN: A GitLab token with `api` scope.
+- TEST_VERBOSE: Set to '-v' to emit test output for debugging purposes
+- CLEANUP_ALL: Set to delete all test repos after testing.
 
 ## Maintainers
 

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -256,6 +256,38 @@ var _ = Describe("GitLab Provider", func() {
 		Expect(*info.DefaultBranch).To(Equal(internal.DefaultBranch))
 	}
 
+	cleanupOrgRepos := func(prefix string) {
+		fmt.Printf("Deleting repos starting with %s in org: %s\n", prefix, testOrgName)
+		repos, err := c.OrgRepositories().List(ctx, newOrgRef(testOrgName))
+		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			// Delete the test org repo used
+			name := repo.Repository().GetRepository()
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			fmt.Printf("Deleting the org repo: %s\n", name)
+			repo.Delete(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	cleanupUserRepos := func(prefix string) {
+		fmt.Printf("Deleting repos starting with %s for user: %s\n", prefix, testUserName)
+		repos, err := c.UserRepositories().List(ctx, newUserRef(testUserName))
+		Expect(err).ToNot(HaveOccurred())
+		for _, repo := range repos {
+			// Delete the test org repo used
+			name := repo.Repository().GetRepository()
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			fmt.Printf("Deleting the org repo: %s\n", name)
+			repo.Delete(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
 	It("should list the available organizations the user has access to", func() {
 		// Get a list of all organizations the user is part of
 		orgs, err := c.Organizations().List(ctx)
@@ -742,6 +774,12 @@ var _ = Describe("GitLab Provider", func() {
 		// Don't do anything more if c wasn't created
 		if c == nil {
 			return
+		}
+
+		if len(os.Getenv("CLEANUP_ALL")) > 0 {
+			defer cleanupOrgRepos("test-org-repo")
+			defer cleanupOrgRepos("test-shared-org-repo")
+			defer cleanupUserRepos("test-repo")
 		}
 		// Delete the test repo used
 		fmt.Println("Deleting the user repo: ", testRepoName)


### PR DESCRIPTION
Changes the GITHUB_TOKEN environmental variable to GITPROVIDER_BOT_TOKEN
because github secrets cannot start with GITHUB_

Add an option to cleanup all test repos, the integration tests sometimes
fail to cleanup.

Signed-off-by: Paul Carlton <paul.carlton@weave.works>

### Description

Changes the GITHUB_TOKEN environmental variable to GITPROVIDER_BOT_TOKEN
because github secrets cannot start with GITHUB_

Add an option to cleanup all test repos, the integration tests sometimes
fail to cleanup.

### Test results

go mod tidy
go fmt ./...
go vet ./...
go test  -race -coverprofile=coverage.txt -covermode=atomic ./...
?       github.com/fluxcd/go-git-providers/bitbucket    [no test files]
ok      github.com/fluxcd/go-git-providers/github       13.859s coverage: 50.8% of statements

ok      github.com/fluxcd/go-git-providers/gitlab       40.272s coverage: 73.9% of statements
ok      github.com/fluxcd/go-git-providers/gitprovider  0.141s  coverage: 94.5% of statements
?       github.com/fluxcd/go-git-providers/gitprovider/cache    [no test files]
?       github.com/fluxcd/go-git-providers/gitprovider/testutils        [no test files]
ok      github.com/fluxcd/go-git-providers/validation   0.058s  coverage: 100.0% of statements
