### PR TITLE
update docs location

### DIFF
--- a/github/example_repository_test.go
+++ b/github/example_repository_test.go
@@ -29,5 +29,5 @@ func ExampleOrgRepositoriesClient_Get() {
 	internalRepo := repo.APIObject().(*gogithub.Repository)
 
 	fmt.Printf("Description: %s. Homepage: %s", *repoInfo.Description, internalRepo.GetHomepage())
-	// Output: Description: The GitOps Kubernetes operator. Homepage: https://docs.fluxcd.io
+	// Output: Description: The GitOps Kubernetes operator. Homepage: https://fluxcd.io/docs
 }


### PR DESCRIPTION
Please also change the website for the GH project to <https://fluxcd.io/docs>.