### PR TITLE
add more info to CommitInfo

### DIFF
--- a/github/example_repository_test.go
+++ b/github/example_repository_test.go
@@ -29,5 +29,5 @@ func ExampleOrgRepositoriesClient_Get() {
 	internalRepo := repo.APIObject().(*gogithub.Repository)
 
 	fmt.Printf("Description: %s. Homepage: %s", *repoInfo.Description, internalRepo.GetHomepage())
-	// Output: Description: The GitOps Kubernetes operator. Homepage: https://fluxcd.io/docs
+	// Output: Description: The GitOps Kubernetes operator. Homepage: https://docs.fluxcd.io
 }

--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -315,6 +315,8 @@ func (c *githubClientImpl) ListCommitsPage(ctx context.Context, owner, repo, bra
 			Tree: &github.Tree{
 				SHA: c.Commit.Tree.SHA,
 			},
+			Author:  c.Commit.Author,
+			Message: c.Commit.Message,
 		})
 	}
 

--- a/github/resource_commit.go
+++ b/github/resource_commit.go
@@ -46,7 +46,10 @@ func (c *commitType) APIObject() interface{} {
 
 func commitFromAPI(apiObj *github.Commit) gitprovider.CommitInfo {
 	return gitprovider.CommitInfo{
-		Sha:     *apiObj.SHA,
-		TreeSha: *apiObj.Tree.SHA,
+		Sha:       *apiObj.SHA,
+		TreeSha:   *apiObj.Tree.SHA,
+		Author:    *apiObj.Author.Name,
+		Message:   *apiObj.Message,
+		CreatedAt: *apiObj.Author.Date,
 	}
 }

--- a/gitlab/gitlabclient.go
+++ b/gitlab/gitlabclient.go
@@ -405,7 +405,10 @@ func (c *gitlabClientImpl) ListCommitsPage(ctx context.Context, projectName stri
 	pageObjs, _, listErr := c.c.Commits.ListCommits(projectName, &opts)
 	for _, c := range pageObjs {
 		apiObjs = append(apiObjs, &gitlab.Commit{
-			ID: c.ID,
+			ID:         c.ID,
+			AuthorName: c.AuthorName,
+			Message:    c.Message,
+			CreatedAt:  c.CreatedAt,
 		})
 	}
 

--- a/gitlab/resource_commit.go
+++ b/gitlab/resource_commit.go
@@ -46,6 +46,9 @@ func (c *commitType) APIObject() interface{} {
 
 func commitFromAPI(apiObj *gitlab.Commit) gitprovider.CommitInfo {
 	return gitprovider.CommitInfo{
-		Sha: apiObj.ID,
+		Sha:       apiObj.ID,
+		Author:    apiObj.AuthorName,
+		Message:   apiObj.Message,
+		CreatedAt: *apiObj.CreatedAt,
 	}
 }

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -14,7 +14,7 @@ import (
 const (
 	alreadyExistsMagicString = "name: [has already been taken]"
 	alreadySharedWithGroup   = "already shared with this group"
-	masterBranchName         = "master"
+	defaultBranchName        = "main"
 )
 
 func getRepoPath(ref gitprovider.RepositoryRef) string {
@@ -173,7 +173,7 @@ func validateProjectAPI(apiObj *gitlab.Project) error {
 		}
 		// Set default branch to master if unset
 		if apiObj.DefaultBranch == "" {
-			apiObj.DefaultBranch = masterBranchName
+			apiObj.DefaultBranch = defaultBranchName
 		}
 	})
 }

--- a/gitprovider/types_defaulting_test.go
+++ b/gitprovider/types_defaulting_test.go
@@ -62,7 +62,7 @@ func TestDefaulting(t *testing.T) {
 			object:     &RepositoryInfo{},
 			expected: &RepositoryInfo{
 				Visibility:    RepositoryVisibilityVar(RepositoryVisibilityPrivate),
-				DefaultBranch: StringVar("master"),
+				DefaultBranch: StringVar("main"),
 			},
 		},
 		{
@@ -70,11 +70,11 @@ func TestDefaulting(t *testing.T) {
 			structName: "Repository",
 			object: &RepositoryInfo{
 				Visibility:    RepositoryVisibilityVar(RepositoryVisibilityPrivate),
-				DefaultBranch: StringVar("master"),
+				DefaultBranch: StringVar("main"),
 			},
 			expected: &RepositoryInfo{
 				Visibility:    RepositoryVisibilityVar(RepositoryVisibilityPrivate),
-				DefaultBranch: StringVar("master"),
+				DefaultBranch: StringVar("main"),
 			},
 		},
 		{

--- a/gitprovider/types_repository.go
+++ b/gitprovider/types_repository.go
@@ -31,7 +31,7 @@ const (
 	// the default branch name.
 	// TODO: When enough Git providers support setting this at both POST and PATCH-time
 	// (including when auto-initing), change this to "main".
-	defaultBranchName = "master"
+	defaultBranchName = "main"
 	// by default, deploy keys are read-only.
 	defaultDeployKeyReadOnly = true
 )

--- a/gitprovider/types_repository.go
+++ b/gitprovider/types_repository.go
@@ -18,6 +18,7 @@ package gitprovider
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/fluxcd/go-git-providers/validation"
 )
@@ -187,6 +188,15 @@ type CommitInfo struct {
 	// TreeSha is the tree sha this commit belongs to.
 	// +required
 	TreeSha string `json:"tree_sha"`
+
+	// Author is the author of the commit
+	Author string `json:"author"`
+
+	// Message is the commit message
+	Message string `json:"message"`
+
+	// CreatedAt is the time the commit was created
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // CommitFile contains high-level information about a file added to a commit.


### PR DESCRIPTION
Signed-off-by: Justin Thompson <justin@weave.works>

### Description
Added author name, commit message, and created at to CommitInfo for weave-gitops use.


### Test results

https://github.com/J-Thompson12/go-git-providers/actions/runs/1113589118