### PR TITLE
Refactors clientOption struct due to duplication

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -18,13 +18,10 @@ package github
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/google/go-github/v32/github"
-	"golang.org/x/oauth2"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/fluxcd/go-git-providers/gitprovider/cache"
 )
 
 const (
@@ -34,177 +31,6 @@ const (
 	// containing a GitHub authentication token.
 	TokenVariable = "GITHUB_TOKEN" // #nosec G101
 )
-
-// ClientOption is the interface to implement for passing options to NewClient.
-// The clientOptions struct is private to force usage of the With... functions.
-type ClientOption interface {
-	// ApplyToGithubClientOptions applies set fields of this object into target.
-	ApplyToGithubClientOptions(target *clientOptions) error
-}
-
-// clientOptions is the struct that tracks data about what options have been set.
-type clientOptions struct {
-	// clientOptions shares all the common options
-	gitprovider.CommonClientOptions
-
-	// AuthTransport is a ChainableRoundTripperFunc adding authentication credentials to the transport chain.
-	AuthTransport gitprovider.ChainableRoundTripperFunc
-
-	// EnableConditionalRequests will be set if conditional requests should be used.
-	// TODO: Move this to gitprovider.CommonClientOptions if other providers support this too.
-	// See: https://developer.github.com/v3/#conditional-requests for more info.
-	// Default: false
-	EnableConditionalRequests *bool
-}
-
-// ApplyToGithubClientOptions implements ClientOption, and applies the set fields of opts
-// into target. If both opts and target has the same specific field set, ErrInvalidClientOptions is returned.
-func (opts *clientOptions) ApplyToGithubClientOptions(target *clientOptions) error {
-	// Apply common values, if any
-	if err := opts.CommonClientOptions.ApplyToCommonClientOptions(&target.CommonClientOptions); err != nil {
-		return err
-	}
-
-	if opts.AuthTransport != nil {
-		// Make sure the user didn't specify the AuthTransport twice
-		if target.AuthTransport != nil {
-			return fmt.Errorf("option AuthTransport already configured: %w", gitprovider.ErrInvalidClientOptions)
-		}
-		target.AuthTransport = opts.AuthTransport
-	}
-
-	if opts.EnableConditionalRequests != nil {
-		// Make sure the user didn't specify the EnableConditionalRequests twice
-		if target.EnableConditionalRequests != nil {
-			return fmt.Errorf("option EnableConditionalRequests already configured: %w", gitprovider.ErrInvalidClientOptions)
-		}
-		target.EnableConditionalRequests = opts.EnableConditionalRequests
-	}
-	return nil
-}
-
-// getTransportChain builds the full chain of transports (from left to right,
-// as per gitprovider.BuildClientFromTransportChain) of the form described in NewClient.
-func (opts *clientOptions) getTransportChain() (chain []gitprovider.ChainableRoundTripperFunc) {
-	if opts.PostChainTransportHook != nil {
-		chain = append(chain, opts.PostChainTransportHook)
-	}
-	if opts.AuthTransport != nil {
-		chain = append(chain, opts.AuthTransport)
-	}
-	if opts.EnableConditionalRequests != nil && *opts.EnableConditionalRequests {
-		// TODO: Provide some kind of debug logging if/when the httpcache is used
-		// One can see if the request hit the cache using: resp.Header[httpcache.XFromCache]
-		chain = append(chain, cache.NewHTTPCacheTransport)
-	}
-	if opts.PreChainTransportHook != nil {
-		chain = append(chain, opts.PreChainTransportHook)
-	}
-	return
-}
-
-// buildCommonOption is a helper for returning a ClientOption out of a common option field.
-func buildCommonOption(opt gitprovider.CommonClientOptions) *clientOptions {
-	return &clientOptions{CommonClientOptions: opt}
-}
-
-// errorOption implements ClientOption, and just wraps an error which is immediately returned.
-// This struct can be used through the optionError function, in order to make makeOptions fail
-// if there are invalid options given to the With... functions.
-type errorOption struct {
-	err error
-}
-
-// ApplyToGithubClientOptions implements ClientOption, but just returns the internal error.
-func (e *errorOption) ApplyToGithubClientOptions(*clientOptions) error { return e.err }
-
-// optionError is a constructor for errorOption.
-func optionError(err error) ClientOption {
-	return &errorOption{err}
-}
-
-//
-// Common options
-//
-
-// WithDomain initializes a Client for a custom GitHub Enterprise instance of the given domain.
-// Only host and port information should be present in domain. domain must not be an empty string.
-func WithDomain(domain string) ClientOption {
-	return buildCommonOption(gitprovider.CommonClientOptions{Domain: &domain})
-}
-
-// WithDestructiveAPICalls tells the client whether it's allowed to do dangerous and possibly destructive
-// actions, like e.g. deleting a repository.
-func WithDestructiveAPICalls(destructiveActions bool) ClientOption {
-	return buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: &destructiveActions})
-}
-
-// WithPreChainTransportHook registers a ChainableRoundTripperFunc "before" the cache and authentication
-// transports in the chain. For more information, see NewClient, and gitprovider.CommonClientOptions.PreChainTransportHook.
-func WithPreChainTransportHook(preRoundTripperFunc gitprovider.ChainableRoundTripperFunc) ClientOption {
-	// Don't allow an empty value
-	if preRoundTripperFunc == nil {
-		return optionError(fmt.Errorf("preRoundTripperFunc cannot be nil: %w", gitprovider.ErrInvalidClientOptions))
-	}
-
-	return buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: preRoundTripperFunc})
-}
-
-// WithPostChainTransportHook registers a ChainableRoundTripperFunc "after" the cache and authentication
-// transports in the chain. For more information, see NewClient, and gitprovider.CommonClientOptions.WithPostChainTransportHook.
-func WithPostChainTransportHook(postRoundTripperFunc gitprovider.ChainableRoundTripperFunc) ClientOption {
-	// Don't allow an empty value
-	if postRoundTripperFunc == nil {
-		return optionError(fmt.Errorf("postRoundTripperFunc cannot be nil: %w", gitprovider.ErrInvalidClientOptions))
-	}
-
-	return buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: postRoundTripperFunc})
-}
-
-//
-// GitHub-specific options
-//
-
-// WithOAuth2Token initializes a Client which authenticates with GitHub through an OAuth2 token.
-// oauth2Token must not be an empty string.
-func WithOAuth2Token(oauth2Token string) ClientOption {
-	// Don't allow an empty value
-	if len(oauth2Token) == 0 {
-		return optionError(fmt.Errorf("oauth2Token cannot be empty: %w", gitprovider.ErrInvalidClientOptions))
-	}
-
-	return &clientOptions{AuthTransport: oauth2Transport(oauth2Token)}
-}
-
-func oauth2Transport(oauth2Token string) gitprovider.ChainableRoundTripperFunc {
-	return func(in http.RoundTripper) http.RoundTripper {
-		// Create a TokenSource of the given access token
-		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: oauth2Token})
-		// Create a Transport, with "in" as the underlying transport, and the given TokenSource
-		return &oauth2.Transport{
-			Base:   in,
-			Source: oauth2.ReuseTokenSource(nil, ts),
-		}
-	}
-}
-
-// WithConditionalRequests instructs the client to use Conditional Requests to GitHub, asking GitHub
-// whether a resource has changed (without burning your quota), and using an in-memory cached "database"
-// if so. See: https://developer.github.com/v3/#conditional-requests for more information.
-func WithConditionalRequests(conditionalRequests bool) ClientOption {
-	return &clientOptions{EnableConditionalRequests: &conditionalRequests}
-}
-
-// makeOptions assembles a clientOptions struct from ClientOption mutator functions.
-func makeOptions(opts ...ClientOption) (*clientOptions, error) {
-	o := &clientOptions{}
-	for _, opt := range opts {
-		if err := opt.ApplyToGithubClientOptions(o); err != nil {
-			return nil, err
-		}
-	}
-	return o, nil
-}
 
 // NewClient creates a new gitprovider.Client instance for GitHub API endpoints.
 //
@@ -221,15 +47,15 @@ func makeOptions(opts ...ClientOption) (*clientOptions, error) {
 //
 // The chain of transports looks like this:
 // github.com API <-> "Post Chain" <-> Authentication <-> Cache <-> "Pre Chain" <-> *github.Client.
-func NewClient(optFns ...ClientOption) (gitprovider.Client, error) {
+func NewClient(optFns ...gitprovider.ClientOption) (gitprovider.Client, error) {
 	// Complete the options struct
-	opts, err := makeOptions(optFns...)
+	opts, err := gitprovider.MakeClientOptions(optFns...)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create a *http.Client using the transport chain
-	httpClient, err := gitprovider.BuildClientFromTransportChain(opts.getTransportChain())
+	httpClient, err := gitprovider.BuildClientFromTransportChain(opts.GetTransportChain())
 	if err != nil {
 		return nil, err
 	}

--- a/github/auth_test.go
+++ b/github/auth_test.go
@@ -17,183 +17,52 @@ limitations under the License.
 package github
 
 import (
-	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/fluxcd/go-git-providers/gitprovider/cache"
-	"github.com/fluxcd/go-git-providers/validation"
 )
 
-func dummyRoundTripper1(http.RoundTripper) http.RoundTripper { return nil }
-func dummyRoundTripper2(http.RoundTripper) http.RoundTripper { return nil }
-func dummyRoundTripper3(http.RoundTripper) http.RoundTripper { return nil }
-
-func roundTrippersEqual(a, b gitprovider.ChainableRoundTripperFunc) bool {
-	if a == nil && b == nil {
-		return true
-	} else if (a != nil && b == nil) || (a == nil && b != nil) {
-		return false
-	}
-	// Note that this comparison relies on "undefined behavior" in the Go language spec, see:
-	// https://stackoverflow.com/questions/9643205/how-do-i-compare-two-functions-for-pointer-equality-in-the-latest-go-weekly
-	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
-}
-
-func Test_clientOptions_getTransportChain(t *testing.T) {
-	tests := []struct {
-		name      string
-		preChain  gitprovider.ChainableRoundTripperFunc
-		postChain gitprovider.ChainableRoundTripperFunc
-		auth      gitprovider.ChainableRoundTripperFunc
-		cache     bool
-		wantChain []gitprovider.ChainableRoundTripperFunc
-	}{
-		{
-			name:      "all roundtrippers",
-			preChain:  dummyRoundTripper1,
-			postChain: dummyRoundTripper2,
-			auth:      dummyRoundTripper3,
-			cache:     true,
-			// expect: "post chain" <-> "auth" <-> "cache" <-> "pre chain"
-			wantChain: []gitprovider.ChainableRoundTripperFunc{
-				dummyRoundTripper2,
-				dummyRoundTripper3,
-				cache.NewHTTPCacheTransport,
-				dummyRoundTripper1,
-			},
-		},
-		{
-			name:     "only pre + auth",
-			preChain: dummyRoundTripper1,
-			auth:     dummyRoundTripper2,
-			// expect: "auth" <-> "pre chain"
-			wantChain: []gitprovider.ChainableRoundTripperFunc{
-				dummyRoundTripper2,
-				dummyRoundTripper1,
-			},
-		},
-		{
-			name:  "only cache + auth",
-			cache: true,
-			auth:  dummyRoundTripper1,
-			// expect: "auth" <-> "cache"
-			wantChain: []gitprovider.ChainableRoundTripperFunc{
-				dummyRoundTripper1,
-				cache.NewHTTPCacheTransport,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := &clientOptions{
-				CommonClientOptions: gitprovider.CommonClientOptions{
-					PreChainTransportHook:  tt.preChain,
-					PostChainTransportHook: tt.postChain,
-				},
-				AuthTransport:             tt.auth,
-				EnableConditionalRequests: &tt.cache,
-			}
-			gotChain := opts.getTransportChain()
-			for i := range tt.wantChain {
-				if !roundTrippersEqual(tt.wantChain[i], gotChain[i]) {
-					t.Errorf("clientOptions.getTransportChain() = %v, want %v", gotChain, tt.wantChain)
-				}
-				break
-			}
-		})
-	}
-}
-
-func Test_makeOptions(t *testing.T) {
+func Test_DomainVariations(t *testing.T) {
 	tests := []struct {
 		name         string
-		opts         []ClientOption
-		want         *clientOptions
+		opts         gitprovider.ClientOption
+		want         string
 		expectedErrs []error
 	}{
 		{
-			name: "no options",
-			want: &clientOptions{},
+			name: "github.com domain",
+			opts: gitprovider.WithDomain("github.com"),
+			want: "github.com",
 		},
 		{
-			name: "WithDomain",
-			opts: []ClientOption{WithDomain("foo")},
-			want: buildCommonOption(gitprovider.CommonClientOptions{Domain: gitprovider.StringVar("foo")}),
+			name: "custom domain without protocol",
+			opts: gitprovider.WithDomain("my-github.dev.com"),
+			want: "my-github.dev.com",
 		},
 		{
-			name:         "WithDomain, empty",
-			opts:         []ClientOption{WithDomain("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+			name: "custom domain with https protocol",
+			opts: gitprovider.WithDomain("https://my-github.dev.com"),
+			want: "https://my-github.dev.com",
 		},
 		{
-			name: "WithDestructiveAPICalls",
-			opts: []ClientOption{WithDestructiveAPICalls(true)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: gitprovider.BoolVar(true)}),
-		},
-		{
-			name: "WithPreChainTransportHook",
-			opts: []ClientOption{WithPreChainTransportHook(dummyRoundTripper1)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: dummyRoundTripper1}),
-		},
-		{
-			name:         "WithPreChainTransportHook, nil",
-			opts:         []ClientOption{WithPreChainTransportHook(nil)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithPostChainTransportHook",
-			opts: []ClientOption{WithPostChainTransportHook(dummyRoundTripper2)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: dummyRoundTripper2}),
-		},
-		{
-			name:         "WithPostChainTransportHook, nil",
-			opts:         []ClientOption{WithPostChainTransportHook(nil)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithOAuth2Token",
-			opts: []ClientOption{WithOAuth2Token("foo")},
-			want: &clientOptions{AuthTransport: oauth2Transport("foo")},
-		},
-		{
-			name:         "WithOAuth2Token, empty",
-			opts:         []ClientOption{WithOAuth2Token("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithConditionalRequests",
-			opts: []ClientOption{WithConditionalRequests(true)},
-			want: &clientOptions{EnableConditionalRequests: gitprovider.BoolVar(true)},
-		},
-		{
-			name:         "WithConditionalRequests, exclusive",
-			opts:         []ClientOption{WithConditionalRequests(true), WithConditionalRequests(false)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
+			name: "custom domain with http protocol",
+			opts: gitprovider.WithDomain("http://my-github.dev.com"),
+			want: "http://my-github.dev.com",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := makeOptions(tt.opts...)
-			validation.TestExpectErrors(t, "makeOptions", err, tt.expectedErrs...)
-			if tt.want == nil {
-				return
-			}
-			if !roundTrippersEqual(got.AuthTransport, tt.want.AuthTransport) ||
-				!roundTrippersEqual(got.PostChainTransportHook, tt.want.PostChainTransportHook) ||
-				!roundTrippersEqual(got.PreChainTransportHook, tt.want.PreChainTransportHook) {
-				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
-			}
-			got.AuthTransport = nil
-			got.PostChainTransportHook = nil
-			got.PreChainTransportHook = nil
-			tt.want.AuthTransport = nil
-			tt.want.PostChainTransportHook = nil
-			tt.want.PreChainTransportHook = nil
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
-			}
+			c1, _ := NewClient(tt.opts)
+			assertEqual(t, tt.want, c1.SupportedDomain())
+
+			c2, _ := NewClient(tt.opts)
+			assertEqual(t, tt.want, c2.SupportedDomain())
 		})
+	}
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	if a != b {
+		t.Fatalf("%s != %s", a, b)
 	}
 }

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -158,10 +158,10 @@ var _ = Describe("GitHub Provider", func() {
 
 		var err error
 		c, err = NewClient(
-			WithOAuth2Token(githubToken),
-			WithDestructiveAPICalls(true),
-			WithConditionalRequests(true),
-			WithPreChainTransportHook(customTransportFactory),
+			gitprovider.WithOAuth2Token(githubToken),
+			gitprovider.WithDestructiveAPICalls(true),
+			gitprovider.WithConditionalRequests(true),
+			gitprovider.WithPreChainTransportHook(customTransportFactory),
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/gitlab/auth.go
+++ b/gitlab/auth.go
@@ -17,13 +17,8 @@ limitations under the License.
 package gitlab
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/fluxcd/go-git-providers/gitprovider/cache"
 	gogitlab "github.com/xanzy/go-gitlab"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -31,183 +26,19 @@ const (
 	DefaultDomain = "gitlab.com"
 )
 
-// ClientOption is the interface to implement for passing options to NewClient.
-// The clientOptions struct is private to force usage of the With... functions.
-type ClientOption interface {
-	// ApplyToGitlabClientOptions applies set fields of this object into target.
-	ApplyToGitlabClientOptions(target *clientOptions) error
-}
-
-// clientOptions is the struct that tracks data about what options have been set.
-type clientOptions struct {
-	// clientOptions shares all the common options
-	gitprovider.CommonClientOptions
-
-	// AuthTransport is a ChainableRoundTripperFunc adding authentication credentials to the transport chain.
-	AuthTransport gitprovider.ChainableRoundTripperFunc
-
-	// EnableConditionalRequests will be set if conditional requests should be used.
-	EnableConditionalRequests *bool
-}
-
-// ApplyToGitlabClientOptions implements ClientOption, and applies the set fields of opts
-// into target. If both opts and target has the same specific field set, ErrInvalidClientOptions is returned.
-func (opts *clientOptions) ApplyToGitlabClientOptions(target *clientOptions) error {
-	// Apply common values, if any
-	if err := opts.CommonClientOptions.ApplyToCommonClientOptions(&target.CommonClientOptions); err != nil {
-		return err
-	}
-
-	if opts.AuthTransport != nil {
-		// Make sure the user didn't specify the AuthTransport twice
-		if target.AuthTransport != nil {
-			return fmt.Errorf("option AuthTransport already configured: %w", gitprovider.ErrInvalidClientOptions)
-		}
-		target.AuthTransport = opts.AuthTransport
-	}
-
-	if opts.EnableConditionalRequests != nil {
-		// Make sure the user didn't specify the EnableConditionalRequests twice
-		if target.EnableConditionalRequests != nil {
-			return fmt.Errorf("option EnableConditionalRequests already configured: %w", gitprovider.ErrInvalidClientOptions)
-		}
-		target.EnableConditionalRequests = opts.EnableConditionalRequests
-	}
-	return nil
-}
-
-// getTransportChain builds the full chain of transports (from left to right,
-// as per gitprovider.BuildClientFromTransportChain) of the form described in NewClient.
-func (opts *clientOptions) getTransportChain() (chain []gitprovider.ChainableRoundTripperFunc) {
-	if opts.PostChainTransportHook != nil {
-		chain = append(chain, opts.PostChainTransportHook)
-	}
-	if opts.AuthTransport != nil {
-		chain = append(chain, opts.AuthTransport)
-	}
-	if opts.EnableConditionalRequests != nil && *opts.EnableConditionalRequests {
-		// TODO: Provide some kind of debug logging if/when the httpcache is used
-		// One can see if the request hit the cache using: resp.Header[httpcache.XFromCache]
-		chain = append(chain, cache.NewHTTPCacheTransport)
-	}
-	if opts.PreChainTransportHook != nil {
-		chain = append(chain, opts.PreChainTransportHook)
-	}
-	return
-}
-
-// buildCommonOption is a helper for returning a ClientOption out of a common option field.
-func buildCommonOption(opt gitprovider.CommonClientOptions) *clientOptions {
-	return &clientOptions{CommonClientOptions: opt}
-}
-
-// errorOption implements ClientOption, and just wraps an error which is immediately returned.
-// This struct can be used through the optionError function, in order to make makeOptions fail
-// if there are invalid options given to the With... functions.
-type errorOption struct {
-	err error
-}
-
-// ApplyToGitlabClientOptions implements ClientOption, but just returns the internal error.
-func (e *errorOption) ApplyToGitlabClientOptions(*clientOptions) error { return e.err }
-
-// optionError is a constructor for errorOption.
-func optionError(err error) ClientOption {
-	return &errorOption{err}
-}
-
-//
-// Common options
-//
-
-// WithDomain initializes a Client for a custom GitLab instance of the given domain.
-// Only host and port information should be present in domain. domain must not be an empty string.
-func WithDomain(domain string) ClientOption {
-	return buildCommonOption(gitprovider.CommonClientOptions{Domain: &domain})
-}
-
-// WithDestructiveAPICalls tells the client whether it's allowed to do dangerous and possibly destructive
-// actions, like e.g. deleting a repository.
-func WithDestructiveAPICalls(destructiveActions bool) ClientOption {
-	return buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: &destructiveActions})
-}
-
-// WithPreChainTransportHook registers a ChainableRoundTripperFunc "before" the cache and authentication
-// transports in the chain. For more information, see NewClient, and gitprovider.CommonClientOptions.PreChainTransportHook.
-func WithPreChainTransportHook(preRoundTripperFunc gitprovider.ChainableRoundTripperFunc) ClientOption {
-	// Don't allow an empty value
-	if preRoundTripperFunc == nil {
-		return optionError(fmt.Errorf("preRoundTripperFunc cannot be nil: %w", gitprovider.ErrInvalidClientOptions))
-	}
-
-	return buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: preRoundTripperFunc})
-}
-
-// WithPostChainTransportHook registers a ChainableRoundTripperFunc "after" the cache and authentication
-// transports in the chain. For more information, see NewClient, and gitprovider.CommonClientOptions.WithPostChainTransportHook.
-func WithPostChainTransportHook(postRoundTripperFunc gitprovider.ChainableRoundTripperFunc) ClientOption {
-	// Don't allow an empty value
-	if postRoundTripperFunc == nil {
-		return optionError(fmt.Errorf("postRoundTripperFunc cannot be nil: %w", gitprovider.ErrInvalidClientOptions))
-	}
-
-	return buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: postRoundTripperFunc})
-}
-
-// WithOAuth2Token initializes a Client which authenticates with GitLab through an OAuth2 token.
-// oauth2Token must not be an empty string.
-func WithOAuth2Token(oauth2Token string) ClientOption {
-	// Don't allow an empty value
-	if len(oauth2Token) == 0 {
-		return optionError(fmt.Errorf("oauth2Token cannot be empty: %w", gitprovider.ErrInvalidClientOptions))
-	}
-
-	return &clientOptions{AuthTransport: oauth2Transport(oauth2Token)}
-}
-
-func oauth2Transport(oauth2Token string) gitprovider.ChainableRoundTripperFunc {
-	return func(in http.RoundTripper) http.RoundTripper {
-		// Create a TokenSource of the given access token
-		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: oauth2Token})
-		// Create a Transport, with "in" as the underlying transport, and the given TokenSource
-		return &oauth2.Transport{
-			Base:   in,
-			Source: oauth2.ReuseTokenSource(nil, ts),
-		}
-	}
-}
-
-// WithConditionalRequests instructs the client to use Conditional Requests to GitLab.
-// See: https://gitlab.com/gitlab-org/gitlab-foss/-/issues/26926, and
-// https://docs.gitlab.com/ee/development/polling.html for more info.
-func WithConditionalRequests(conditionalRequests bool) ClientOption {
-	return &clientOptions{EnableConditionalRequests: &conditionalRequests}
-}
-
-// makeOptions assembles a clientOptions struct from ClientOption mutator functions.
-func makeOptions(opts ...ClientOption) (*clientOptions, error) {
-	o := &clientOptions{}
-	for _, opt := range opts {
-		if err := opt.ApplyToGitlabClientOptions(o); err != nil {
-			return nil, err
-		}
-	}
-	return o, nil
-}
-
 // NewClient creates a new gitlab.Client instance for GitLab API endpoints.
-func NewClient(token string, tokenType string, optFns ...ClientOption) (gitprovider.Client, error) {
+func NewClient(token string, tokenType string, optFns ...gitprovider.ClientOption) (gitprovider.Client, error) {
 	var gl *gogitlab.Client
 	var domain, sshDomain string
 
 	// Complete the options struct
-	opts, err := makeOptions(optFns...)
+	opts, err := gitprovider.MakeClientOptions(optFns...)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create a *http.Client using the transport chain
-	httpClient, err := gitprovider.BuildClientFromTransportChain(opts.getTransportChain())
+	httpClient, err := gitprovider.BuildClientFromTransportChain(opts.GetTransportChain())
 	if err != nil {
 		return nil, err
 	}

--- a/gitlab/auth_test.go
+++ b/gitlab/auth_test.go
@@ -17,211 +17,36 @@ limitations under the License.
 package gitlab
 
 import (
-	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/fluxcd/go-git-providers/gitprovider/cache"
-	"github.com/fluxcd/go-git-providers/validation"
 )
-
-func dummyRoundTripper1(http.RoundTripper) http.RoundTripper { return nil }
-func dummyRoundTripper2(http.RoundTripper) http.RoundTripper { return nil }
-func dummyRoundTripper3(http.RoundTripper) http.RoundTripper { return nil }
-
-func roundTrippersEqual(a, b gitprovider.ChainableRoundTripperFunc) bool {
-	if a == nil && b == nil {
-		return true
-	} else if (a != nil && b == nil) || (a == nil && b != nil) {
-		return false
-	}
-	// Note that this comparison relies on "undefined behavior" in the Go language spec, see:
-	// https://stackoverflow.com/questions/9643205/how-do-i-compare-two-functions-for-pointer-equality-in-the-latest-go-weekly
-	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
-}
-
-func Test_clientOptions_getTransportChain(t *testing.T) {
-	tests := []struct {
-		name      string
-		preChain  gitprovider.ChainableRoundTripperFunc
-		postChain gitprovider.ChainableRoundTripperFunc
-		auth      gitprovider.ChainableRoundTripperFunc
-		cache     bool
-		wantChain []gitprovider.ChainableRoundTripperFunc
-	}{
-		{
-			name:      "all roundtrippers",
-			preChain:  dummyRoundTripper1,
-			postChain: dummyRoundTripper2,
-			auth:      dummyRoundTripper3,
-			cache:     true,
-			// expect: "post chain" <-> "auth" <-> "cache" <-> "pre chain"
-			wantChain: []gitprovider.ChainableRoundTripperFunc{
-				dummyRoundTripper2,
-				dummyRoundTripper3,
-				cache.NewHTTPCacheTransport,
-				dummyRoundTripper1,
-			},
-		},
-		{
-			name:     "only pre + auth",
-			preChain: dummyRoundTripper1,
-			auth:     dummyRoundTripper2,
-			// expect: "auth" <-> "pre chain"
-			wantChain: []gitprovider.ChainableRoundTripperFunc{
-				dummyRoundTripper2,
-				dummyRoundTripper1,
-			},
-		},
-		{
-			name:  "only cache + auth",
-			cache: true,
-			auth:  dummyRoundTripper1,
-			// expect: "auth" <-> "cache"
-			wantChain: []gitprovider.ChainableRoundTripperFunc{
-				dummyRoundTripper1,
-				cache.NewHTTPCacheTransport,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := &clientOptions{
-				CommonClientOptions: gitprovider.CommonClientOptions{
-					PreChainTransportHook:  tt.preChain,
-					PostChainTransportHook: tt.postChain,
-				},
-				AuthTransport: tt.auth,
-			}
-			gotChain := opts.getTransportChain()
-			for i := range tt.wantChain {
-				if !roundTrippersEqual(tt.wantChain[i], gotChain[i]) {
-					t.Errorf("clientOptions.getTransportChain() = %v, want %v", gotChain, tt.wantChain)
-				}
-				break
-			}
-		})
-	}
-}
-
-func Test_makeOptions(t *testing.T) {
-	tests := []struct {
-		name         string
-		opts         []ClientOption
-		want         *clientOptions
-		expectedErrs []error
-	}{
-		{
-			name: "no options",
-			want: &clientOptions{},
-		},
-		{
-			name: "WithDomain",
-			opts: []ClientOption{WithDomain("foo")},
-			want: buildCommonOption(gitprovider.CommonClientOptions{Domain: gitprovider.StringVar("foo")}),
-		},
-		{
-			name:         "WithDomain, empty",
-			opts:         []ClientOption{WithDomain("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithDestructiveAPICalls",
-			opts: []ClientOption{WithDestructiveAPICalls(true)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{EnableDestructiveAPICalls: gitprovider.BoolVar(true)}),
-		},
-		{
-			name: "WithPreChainTransportHook",
-			opts: []ClientOption{WithPreChainTransportHook(dummyRoundTripper1)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{PreChainTransportHook: dummyRoundTripper1}),
-		},
-		{
-			name:         "WithPreChainTransportHook, nil",
-			opts:         []ClientOption{WithPreChainTransportHook(nil)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithPostChainTransportHook",
-			opts: []ClientOption{WithPostChainTransportHook(dummyRoundTripper2)},
-			want: buildCommonOption(gitprovider.CommonClientOptions{PostChainTransportHook: dummyRoundTripper2}),
-		},
-		{
-			name:         "WithPostChainTransportHook, nil",
-			opts:         []ClientOption{WithPostChainTransportHook(nil)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithOAuth2Token",
-			opts: []ClientOption{WithOAuth2Token("foo")},
-			want: &clientOptions{AuthTransport: oauth2Transport("foo")},
-		},
-		{
-			name:         "WithOAuth2Token, empty",
-			opts:         []ClientOption{WithOAuth2Token("")},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-		{
-			name: "WithConditionalRequests",
-			opts: []ClientOption{WithConditionalRequests(true)},
-			want: &clientOptions{EnableConditionalRequests: gitprovider.BoolVar(true)},
-		},
-		{
-			name:         "WithConditionalRequests, exclusive",
-			opts:         []ClientOption{WithConditionalRequests(true), WithConditionalRequests(false)},
-			expectedErrs: []error{gitprovider.ErrInvalidClientOptions},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := makeOptions(tt.opts...)
-			validation.TestExpectErrors(t, "makeOptions", err, tt.expectedErrs...)
-			if tt.want == nil {
-				return
-			}
-			if !roundTrippersEqual(got.AuthTransport, tt.want.AuthTransport) ||
-				!roundTrippersEqual(got.PostChainTransportHook, tt.want.PostChainTransportHook) ||
-				!roundTrippersEqual(got.PreChainTransportHook, tt.want.PreChainTransportHook) {
-				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
-			}
-			got.AuthTransport = nil
-			got.PostChainTransportHook = nil
-			got.PreChainTransportHook = nil
-			tt.want.AuthTransport = nil
-			tt.want.PostChainTransportHook = nil
-			tt.want.PreChainTransportHook = nil
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func Test_DomainVariations(t *testing.T) {
 	tests := []struct {
 		name         string
-		opts         ClientOption
+		opts         gitprovider.ClientOption
 		want         string
 		expectedErrs []error
 	}{
 		{
 			name: "gitlab.com domain",
-			opts: WithDomain("gitlab.com"),
+			opts: gitprovider.WithDomain("gitlab.com"),
 			want: "https://gitlab.com",
 		},
 		{
 			name: "custom domain without protocol",
-			opts: WithDomain("my-gitlab.dev.com"),
+			opts: gitprovider.WithDomain("my-gitlab.dev.com"),
 			want: "https://my-gitlab.dev.com",
 		},
 		{
 			name: "custom domain with https protocol",
-			opts: WithDomain("https://my-gitlab.dev.com"),
+			opts: gitprovider.WithDomain("https://my-gitlab.dev.com"),
 			want: "https://my-gitlab.dev.com",
 		},
 		{
 			name: "custom domain with http protocol",
-			opts: WithDomain("http://my-gitlab.dev.com"),
+			opts: gitprovider.WithDomain("http://my-gitlab.dev.com"),
 			want: "http://my-gitlab.dev.com",
 		},
 	}

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -216,10 +216,10 @@ var _ = Describe("GitLab Provider", func() {
 		var err error
 		c, err = NewClient(
 			gitlabToken, "",
-			WithDomain(gitlabDomain),
-			WithDestructiveAPICalls(true),
-			WithConditionalRequests(true),
-			WithPreChainTransportHook(customTransportFactory),
+			gitprovider.WithDomain(gitlabDomain),
+			gitprovider.WithDestructiveAPICalls(true),
+			gitprovider.WithConditionalRequests(true),
+			gitprovider.WithPreChainTransportHook(customTransportFactory),
 		)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/gitprovider/client_options_test.go
+++ b/gitprovider/client_options_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/fluxcd/go-git-providers/validation"
 )
 
+func dummyRoundTripper1(http.RoundTripper) http.RoundTripper { return nil }
+func dummyRoundTripper2(http.RoundTripper) http.RoundTripper { return nil }
+func dummyRoundTripper3(http.RoundTripper) http.RoundTripper { return nil }
+
 func roundTrippersEqual(a, b ChainableRoundTripperFunc) bool {
 	if a == nil && b == nil {
 		return true
@@ -64,8 +68,6 @@ func withPreChainTransportHook(preRoundTripperFunc ChainableRoundTripperFunc) co
 func withPostChainTransportHook(postRoundTripperFunc ChainableRoundTripperFunc) commonClientOption {
 	return &CommonClientOptions{PostChainTransportHook: postRoundTripperFunc}
 }
-
-func dummyRoundTripper1(http.RoundTripper) http.RoundTripper { return nil }
 
 func Test_makeOptions(t *testing.T) {
 	tests := []struct {
@@ -137,6 +139,161 @@ func Test_makeOptions(t *testing.T) {
 			}
 			got.PostChainTransportHook = nil
 			got.PreChainTransportHook = nil
+			tt.want.PostChainTransportHook = nil
+			tt.want.PreChainTransportHook = nil
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_clientOptions_getTransportChain(t *testing.T) {
+	tests := []struct {
+		name      string
+		preChain  ChainableRoundTripperFunc
+		postChain ChainableRoundTripperFunc
+		auth      ChainableRoundTripperFunc
+		cache     bool
+		wantChain []ChainableRoundTripperFunc
+	}{
+		{
+			name:      "all roundtrippers",
+			preChain:  dummyRoundTripper1,
+			postChain: dummyRoundTripper2,
+			auth:      dummyRoundTripper3,
+			cache:     true,
+			// expect: "post chain" <-> "auth" <-> "cache" <-> "pre chain"
+			wantChain: []ChainableRoundTripperFunc{
+				dummyRoundTripper2,
+				dummyRoundTripper3,
+				dummyRoundTripper1,
+			},
+		},
+		{
+			name:     "only pre + auth",
+			preChain: dummyRoundTripper1,
+			auth:     dummyRoundTripper2,
+			// expect: "auth" <-> "pre chain"
+			wantChain: []ChainableRoundTripperFunc{
+				dummyRoundTripper2,
+				dummyRoundTripper1,
+			},
+		},
+		{
+			name:  "only cache + auth",
+			cache: true,
+			auth:  dummyRoundTripper1,
+			// expect: "auth" <-> "cache"
+			wantChain: []ChainableRoundTripperFunc{
+				dummyRoundTripper1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dummy := "dummy"
+			opts := &clientOptions{
+				CommonClientOptions: CommonClientOptions{
+					Domain:                 &dummy,
+					PreChainTransportHook:  tt.preChain,
+					PostChainTransportHook: tt.postChain,
+				},
+				authTransport: tt.auth,
+			}
+			gotChain := opts.GetTransportChain()
+			for i := range tt.wantChain {
+				if !roundTrippersEqual(tt.wantChain[i], gotChain[i]) {
+					t.Fatalf("%s - clientOptions.getTransportChain() = %v, want %v", tt.name, gotChain, tt.wantChain)
+				}
+			}
+		})
+	}
+}
+
+func Test_makeCientOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         []ClientOption
+		want         *clientOptions
+		expectedErrs []error
+	}{
+		{
+			name: "no options",
+			want: &clientOptions{},
+		},
+		{
+			name: "WithDomain",
+			opts: []ClientOption{WithDomain("foo")},
+			want: buildCommonOption(CommonClientOptions{Domain: StringVar("foo")}),
+		},
+		{
+			name:         "WithDomain, empty",
+			opts:         []ClientOption{WithDomain("")},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "WithDestructiveAPICalls",
+			opts: []ClientOption{WithDestructiveAPICalls(true)},
+			want: buildCommonOption(CommonClientOptions{EnableDestructiveAPICalls: BoolVar(true)}),
+		},
+		{
+			name: "WithPreChainTransportHook",
+			opts: []ClientOption{WithPreChainTransportHook(dummyRoundTripper1)},
+			want: buildCommonOption(CommonClientOptions{PreChainTransportHook: dummyRoundTripper1}),
+		},
+		{
+			name:         "WithPreChainTransportHook, nil",
+			opts:         []ClientOption{WithPreChainTransportHook(nil)},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "WithPostChainTransportHook",
+			opts: []ClientOption{WithPostChainTransportHook(dummyRoundTripper2)},
+			want: buildCommonOption(CommonClientOptions{PostChainTransportHook: dummyRoundTripper2}),
+		},
+		{
+			name:         "WithPostChainTransportHook, nil",
+			opts:         []ClientOption{WithPostChainTransportHook(nil)},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "WithOAuth2Token",
+			opts: []ClientOption{WithOAuth2Token("foo")},
+			want: &clientOptions{authTransport: oauth2Transport("foo")},
+		},
+		{
+			name:         "WithOAuth2Token, empty",
+			opts:         []ClientOption{WithOAuth2Token("")},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+		{
+			name: "WithConditionalRequests",
+			opts: []ClientOption{WithConditionalRequests(true)},
+			want: &clientOptions{enableConditionalRequests: BoolVar(true)},
+		},
+		{
+			name:         "WithConditionalRequests, exclusive",
+			opts:         []ClientOption{WithConditionalRequests(true), WithConditionalRequests(false)},
+			expectedErrs: []error{ErrInvalidClientOptions},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MakeClientOptions(tt.opts...)
+			validation.TestExpectErrors(t, "makeOptions", err, tt.expectedErrs...)
+			if tt.want == nil {
+				return
+			}
+			if !roundTrippersEqual(got.authTransport, tt.want.authTransport) ||
+				!roundTrippersEqual(got.PostChainTransportHook, tt.want.PostChainTransportHook) ||
+				!roundTrippersEqual(got.PreChainTransportHook, tt.want.PreChainTransportHook) {
+				t.Errorf("makeOptions() = %v, want %v", got, tt.want)
+			}
+			got.authTransport = nil
+			got.PostChainTransportHook = nil
+			got.PreChainTransportHook = nil
+			tt.want.authTransport = nil
 			tt.want.PostChainTransportHook = nil
 			tt.want.PreChainTransportHook = nil
 			if !reflect.DeepEqual(got, tt.want) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fluxcd/go-git-providers
 go 1.15
 
 require (
+	github.com/go-logr/logr v1.1.0
 	github.com/google/go-cmp v0.4.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/go-logr/logr v1.1.0 h1:nAbevmWlS2Ic4m4+/An5NXkaGqlqpbBgdcuThZxnZyI=
+github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

### Description

This work is to prepare the stash implementation.

gitlab/auth.go and github/auth.go duplicate most of their code and tests.

The code has been moved to the gitprovider pkg along with the tests.


### Test results

https://github.com/souleb/go-git-providers/actions/runs/1186522224
