### PR TITLE
upgrade Go version to 1.16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
       - name: Run vet
         run: make tidy fmt vet
       - name: Check if working tree is dirty

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
       - name: Run tests
         run: |
           [ -n "${{ secrets.GITLAB_TOKEN }}" ] && export GITLAB_TOKEN=${{ secrets.GITLAB_TOKEN }} || echo "using default GITLAB_TOKEN"

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       # Similar as to https://github.com/fluxcd/toolkit/blob/master/.github/workflows/release.yaml#L20-L27
       - name: Download release notes utility
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/go-git-providers
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,6 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

### Description

move from Go version 1.15 to 1.16


### Test results

https://github.com/souleb/go-git-providers/runs/3535773876?check_suite_focus=true
