### PR TITLE
fix often failing e2e tests

### DIFF
--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -389,8 +389,11 @@ var _ = Describe("GitHub Provider", func() {
 				AutoInit:        gitprovider.BoolVar(true),
 				LicenseTemplate: gitprovider.LicenseTemplateVar(gitprovider.LicenseTemplateMIT),
 			})
+			if err == nil && !actionTaken {
+				err = errors.New("expecting action taken to be true")
+			}
 			return retryOp.Retry(err, fmt.Sprintf("reconcile user repository: %s", repoRef.RepositoryName))
-		}, retryOp.Timeout(), retryOp.Interval()).Should(BeTrue())
+		}, time.Second*90, retryOp.Interval()).Should(BeTrue())
 
 		Expect(actionTaken).To(BeTrue())
 		validateRepo(newRepo, repoRef)


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

### Description
The culprit is a test on the github test suite named
"should update if the repository already exists when reconciling"

### Test results

https://github.com/souleb/go-git-providers/actions/runs/1213132680
