### PR TITLE
[Stash] This add the stash client service GroupService

### DIFF
--- a/stash/client.go
+++ b/stash/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gostash
+package stash
 
 import (
 	"bytes"
@@ -75,6 +75,8 @@ type Doer interface {
 // It can be used for example to setup a custom http Client.
 type ClientOptionsFunc func(Client *Client)
 
+type service struct{ Client *Client }
+
 // A Client is a retryable HTTP Client.
 // The Client will automatically retry when it encounters recoverable errors.
 // The Client will also retry when it encounters a 429 Too Many Requests status.
@@ -98,7 +100,8 @@ type Client struct {
 	Logger *logr.Logger
 
 	// Services are used to communicate with the different stash endpoints.
-	Users *UsersService
+	Users  Users
+	Groups Groups
 }
 
 // RateLimiter is the interface that wraps the basic Wait method.
@@ -169,10 +172,8 @@ func NewClient(httpClient *http.Client, host string, header *http.Header, logger
 
 	c.HeaderFields = header
 
-	c.Users = &UsersService{
-		Client: c,
-		log:    *c.Logger,
-	}
+	c.Users = &UsersService{Client: c}
+	c.Groups = &GroupsService{Client: c}
 
 	return c, nil
 }

--- a/stash/client_test.go
+++ b/stash/client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gostash
+package stash
 
 import (
 	"bytes"

--- a/stash/groups.go
+++ b/stash/groups.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	groupsURI       = "admin/groups"
+	groupMembersURI = "admin/groups/more-members"
+)
+
+// Groups interface defines the methods that can be used to
+// retrieve groups and members of a group.
+type Groups interface {
+	List(ctx context.Context, opts *PagingOptions) (*GroupList, error)
+	Get(ctx context.Context, groupName string) (*Group, error)
+	ListGroupMembers(ctx context.Context, groupName string, opts *PagingOptions) (*GroupMembers, error)
+}
+
+// GroupsService is a client for communicating with stash groups endpoint
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+type GroupsService service
+
+// Group represents a stash group.
+type Group struct {
+	// Session is the session object for the group.
+	Session Session `json:"sessionInfo,omitempty"`
+	// Name is the name of the group.
+	Name string `json:"name,omitempty"`
+	// Delete is the delete flag for the group.
+	Deleteable bool `json:"deletable,omitempty"`
+}
+
+// GroupList represents  a list of stash groups.
+type GroupList struct {
+	// Paging is the paging information.
+	Paging
+	// Groups is the list of stash groups.
+	Groups []*Group `json:"values,omitempty"`
+}
+
+// GetGroups returns a slice of groups.
+func (g *GroupList) GetGroups() []*Group {
+	return g.Groups
+}
+
+// List retrieves a list of stash groups.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a paging struct is returned to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/admin/groups".
+// The authenticated user must have the LICENSED_USER permission to call this resource.
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *GroupsService) List(ctx context.Context, opts *PagingOptions) (*GroupList, error) {
+	query := addPaging(&url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupsURI), *query, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list groups failed: , %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list groups failed: , %w", err)
+	}
+
+	// As nothing is done with the response body, it is safe to close here
+	// to avoid leaking connections
+	defer resp.Body.Close()
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	g := &GroupList{
+		Groups: []*Group{},
+	}
+	if err := json.Unmarshal(res, g); err != nil {
+		return nil, fmt.Errorf("list groups failed, unable to unmarshal repository list json: , %w", err)
+	}
+
+	for _, r := range g.GetGroups() {
+		r.Session.set(resp)
+	}
+
+	return g, nil
+}
+
+// Get retrieves a stash group given it's name.
+// Get uses the endpoint "GET /rest/api/1.0/admin/groups".
+// The authenticated user must have the LICENSED_USER permission to call this resource.
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *GroupsService) Get(ctx context.Context, groupName string) (*Group, error) {
+	query := &url.Values{
+		"filter": []string{groupName},
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupsURI), *query, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list groups failed: , %w", err)
+	}
+
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get group failed: , %w", err)
+	}
+
+	// As nothing is done with the response body, it is safe to close here
+	// to avoid leaking connections
+	defer resp.Body.Close()
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	g := &Group{
+		Name: groupName,
+	}
+
+	if err := json.Unmarshal(res, g); err != nil {
+		return nil, fmt.Errorf("get group failed, unable to unmarshal repository list json: , %w", err)
+	}
+
+	g.Session.set(resp)
+	return g, nil
+}
+
+// GroupMembers  is a list of stash groups members.
+type GroupMembers struct {
+	// Paging is the paging information.
+	Paging
+	// GroupName is the name of the group.
+	GroupName string `json:"-"`
+	// Users is the list of stash groups members.
+	Users []*User `json:"values,omitempty"`
+}
+
+// GetGroupMembers retrieves a list of stash groups members.
+func (m *GroupMembers) GetGroupMembers() []*User {
+	return m.Users
+}
+
+// ListGroupMembers retrieves a list of stash groups members.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a paging struct is returned to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/admin/groups/more-members".
+// The authenticated user must have the LICENSED_USER permission to call this resource.
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *GroupsService) ListGroupMembers(ctx context.Context, groupName string, opts *PagingOptions) (*GroupMembers, error) {
+	query := &url.Values{}
+	query = addPaging(query, opts)
+	// The group name is required as a parameter
+	query.Set(contextKey, groupName)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupMembersURI), *query, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list groups request creation failed: , %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list group members failed: , %w", err)
+	}
+
+	// As nothing is done with the response body, it is safe to close here
+	// to avoid leaking connections
+	defer resp.Body.Close()
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	m := &GroupMembers{
+		GroupName: groupName,
+		Users:     []*User{},
+	}
+
+	if err := json.Unmarshal(res, m); err != nil {
+		return nil, fmt.Errorf("list group members failed, unable to unmarshal repository list json: , %w", err)
+	}
+
+	for _, member := range m.GetGroupMembers() {
+		member.Session.set(resp)
+	}
+
+	return m, nil
+}

--- a/stash/groups_test.go
+++ b/stash/groups_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetGroup(t *testing.T) {
+	tests := []struct {
+		name      string
+		groupName string
+		output    string
+	}{
+		{
+			name:      "test group does not exist",
+			groupName: "admin",
+		},
+		{
+			name:      "test a group",
+			groupName: "dev-1",
+		},
+	}
+
+	validNames := []string{"dev-1"}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s", stashURIprefix, groupsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		for _, substr := range validNames {
+			if strings.Contains(r.Form.Get("filter"), substr) {
+				w.WriteHeader(http.StatusOK)
+				u := &Group{
+					Name: substr,
+				}
+				json.NewEncoder(w).Encode(u)
+				return
+			}
+		}
+
+		http.Error(w, "The specified group does not exist", http.StatusNotFound)
+
+		return
+
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			group, err := client.Groups.Get(ctx, tt.groupName)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Fatalf("Groups.GetGroup returned error: %v", err)
+				}
+				return
+			}
+
+			if group.Name != tt.groupName {
+				t.Errorf("Groups.GetGroup returned group %s, want %s", group.Name, tt.groupName)
+			}
+
+		})
+	}
+}
+
+func TestListGroup(t *testing.T) {
+	gNames := []*Group{
+		{Name: "avengers"}, {Name: "x-men"}, {Name: "ff4"}, {Name: "x-team"}}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s", stashURIprefix, groupsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		u := struct {
+			Groups []*Group `json:"values"`
+		}{[]*Group{
+			gNames[0],
+			gNames[1],
+			gNames[2],
+			gNames[3],
+		}}
+		json.NewEncoder(w).Encode(u)
+		return
+
+	})
+	ctx := context.Background()
+	list, err := client.Groups.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("Groups.GetGroupList returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(gNames, list.Groups); diff != "" {
+		t.Errorf("Groups.List returned diff (want -> got):\n%s", diff)
+	}
+
+}
+
+func TestListGroupMembers(t *testing.T) {
+	wants := []*User{
+		{Name: "John Citizen", Slug: "jcitizen"},
+		{Name: "Tony Stark", Slug: "tstark"},
+		{Name: "Reed Richards", Slug: "rrichards"},
+		{Name: "Riri Williams", Slug: "rwilliams"}}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s", stashURIprefix, groupMembersURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "testGroup") {
+			w.WriteHeader(http.StatusOK)
+			u := struct {
+				Users []*User `json:"values"`
+			}{[]*User{
+				wants[0],
+				wants[1],
+				wants[2],
+				wants[3],
+			}}
+			json.NewEncoder(w).Encode(u)
+			return
+		}
+
+	})
+	ctx := context.Background()
+	list, err := client.Groups.ListGroupMembers(ctx, "testGroup", nil)
+	if err != nil {
+		t.Fatalf("Groups.ListGroupMembers returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(wants, list.Users); diff != "" {
+		t.Errorf("Groups.ListGroupMembers returned diff (want -> got):\n%s", diff)
+	}
+}

--- a/stash/resources.go
+++ b/stash/resources.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gostash
+package stash
 
 import (
 	"net/http"

--- a/stash/users.go
+++ b/stash/users.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gostash
+package stash
 
 import (
 	"context"
@@ -24,8 +24,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/go-logr/logr"
 )
 
 const (
@@ -37,13 +35,16 @@ var (
 	ErrNotFound = fmt.Errorf("not found")
 )
 
+// Users interface defines the methods that can be used to
+// retrieve users.
+type Users interface {
+	List(ctx context.Context, opts *PagingOptions) (*UserList, error)
+	Get(ctx context.Context, userName string) (*User, error)
+}
+
 // UsersService is a client for communicating with stash users endpoint
 // Stash API docs: https://docs.atlassian.com/DAC/rest/stash/3.11.3/stash-rest.html
-type UsersService struct {
-	// Client is the client used to communicate with the Stash API.
-	Client *Client
-	log    logr.Logger
-}
+type UsersService service
 
 // User represents a Stash user.
 type User struct {
@@ -129,9 +130,9 @@ func (s *UsersService) List(ctx context.Context, opts *PagingOptions) (*UserList
 	return u, nil
 }
 
-// GetUser retrieves a user by name.
+// Get retrieves a user by name.
 // Get uses the endpoint "GET /rest/api/1.0/users/{userSlug}".
-func (s *UsersService) GetUser(ctx context.Context, userSlug string) (*User, error) {
+func (s *UsersService) Get(ctx context.Context, userSlug string) (*User, error) {
 	var query *url.Values
 	query = addPaging(query, &PagingOptions{})
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(usersURI, userSlug), *query, nil, nil)


### PR DESCRIPTION
#102 

Signed-off-by: Soule BA <soule@weave.works>

### Description

This add the client service GroupService to communicate with the following rest endpoints:
- /rest/api/1.0/admin/groups
- /rest/api/1.0/admin/groups/more-members


### Test results

https://github.com/souleb/go-git-providers/runs/3587059251?check_suite_focus=true