### PR TITLE
[Stash] adds projects service to the gostash client

### DIFF
--- a/stash/client.go
+++ b/stash/client.go
@@ -17,9 +17,7 @@ limitations under the License.
 package stash
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -100,8 +98,9 @@ type Client struct {
 	Logger *logr.Logger
 
 	// Services are used to communicate with the different stash endpoints.
-	Users  Users
-	Groups Groups
+	Users    Users
+	Groups   Groups
+	Projects Projects
 }
 
 // RateLimiter is the interface that wraps the basic Wait method.
@@ -174,6 +173,7 @@ func NewClient(httpClient *http.Client, host string, header *http.Header, logger
 
 	c.Users = &UsersService{Client: c}
 	c.Groups = &GroupsService{Client: c}
+	c.Projects = &ProjectsService{Client: c}
 
 	return c, nil
 }
@@ -307,12 +307,52 @@ func (c *Client) configureLimiter() error {
 	return nil
 }
 
+// RequestOptions defines the optional parameters for the request.
+type RequestOptions struct {
+	// Body is the request body.
+	Body io.Reader
+	// Header is the request header.
+	Header http.Header
+	// Query is the request query.
+	Query url.Values
+}
+
+// RequestOptionFunc is a function that set request options.
+type RequestOptionFunc func(*RequestOptions)
+
+// WithQuery adds the query parameters to the request.
+func WithQuery(query url.Values) RequestOptionFunc {
+	return func(r *RequestOptions) {
+		if query != nil {
+			r.Query = query
+		}
+	}
+}
+
+// WithBody adds the body to the request.
+func WithBody(body io.Reader) RequestOptionFunc {
+	return func(r *RequestOptions) {
+		if body != nil {
+			r.Body = body
+		}
+	}
+}
+
+// WithHeader adds the headers to the request.
+func WithHeader(header http.Header) RequestOptionFunc {
+	return func(r *RequestOptions) {
+		if header != nil {
+			r.Header = header
+		}
+	}
+}
+
 // NewRequest creates a request, and returns an http.Request and an error,
-// given a path and optional method, query, body, and header.
+// given a path and optional query, body, and header. Use the currying functions provided to pass in the request options
 // A relative URL path can be provided in path, in which case it is resolved relative to the base URL of the Client.
 // Relative URL paths should always be specified without a preceding slash.
 // If specified, the value pointed to by body is JSON encoded and included as the request body.
-func (c *Client) NewRequest(ctx context.Context, method string, path string, query url.Values, body interface{}, header http.Header) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method string, path string, opts ...RequestOptionFunc) (*http.Request, error) {
 	u := *c.BaseURL
 	unescaped, err := url.PathUnescape(path)
 	if err != nil {
@@ -327,25 +367,30 @@ func (c *Client) NewRequest(ctx context.Context, method string, path string, que
 		method = http.MethodGet
 	}
 
-	var bodyReader io.ReadCloser
-	if (method == http.MethodPost || method == http.MethodPut) && body != nil {
-		jsonBody, e := json.Marshal(body)
-		if e != nil {
-			return nil, fmt.Errorf("failed to marshall request body, %w", e)
-		}
-
-		bodyReader = io.NopCloser(bytes.NewReader(jsonBody))
-
-		c.Logger.V(2).Info("request", "body", string(jsonBody))
+	r := RequestOptions{}
+	for _, opt := range opts {
+		opt(&r)
 	}
 
-	if query == nil {
-		query = url.Values{}
+	//var bodyReader io.ReadCloser
+	//if (method == http.MethodPost || method == http.MethodPut) && body != nil {
+	//	jsonBody, e := json.Marshal(body)
+	//	if e != nil {
+	//		return nil, fmt.Errorf("failed to marshall request body, %w", e)
+	//	}
+	//
+	//	bodyReader = io.NopCloser(bytes.NewReader(jsonBody))
+	//
+	//	c.Logger.V(2).Info("request", "body", string(jsonBody))
+	//}
+
+	if r.Query == nil {
+		r.Query = url.Values{}
 	}
 
-	u.RawQuery = query.Encode()
+	u.RawQuery = r.Query.Encode()
 
-	req, err := http.NewRequest(method, u.String(), bodyReader)
+	req, err := http.NewRequest(method, u.String(), r.Body)
 	if err != nil {
 		return req, fmt.Errorf("failed create request for %s %s, %w", method, u.String(), err)
 	}
@@ -360,8 +405,8 @@ func (c *Client) NewRequest(ctx context.Context, method string, path string, que
 		}
 	}
 
-	if header != nil {
-		for k, v := range header {
+	if r.Header != nil {
+		for k, v := range r.Header {
 			for _, s := range v {
 				req.Header.Add(k, s)
 			}
@@ -374,7 +419,7 @@ func (c *Client) NewRequest(ctx context.Context, method string, path string, que
 // Do performs a request, and returns an http.Response and an error given an http.Request.
 // For an outgoing Client request, the context controls the entire lifetime of a reques:
 // obtaining a connection, sending the request, checking errors and retrying.
-// The response body is not closed.
+// The response body is closed.
 func (c *Client) Do(request *http.Request) ([]byte, *http.Response, error) {
 	// If not yet configured, try to configure the rate limiter. Fail
 	// silently as the limiter will be disabled in case of an error.
@@ -421,6 +466,8 @@ func getRespBody(resp *http.Response) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	resp.Body.Close()
 
 	return data, nil
 }

--- a/stash/client_test.go
+++ b/stash/client_test.go
@@ -35,7 +35,7 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func Test_NewRequester(t *testing.T) {
+func Test_NewClient(t *testing.T) {
 	tests := []struct {
 		name      string
 		host      string
@@ -176,7 +176,7 @@ func Test_Do(t *testing.T) {
 	// declare a Client
 	c, err := NewClient(nil, defaultHost, berearHeader, initLogger(t))
 	if err != nil {
-		t.Errorf("unexpected error while declaring a client: %v", err)
+		t.Fatalf("unexpected error while declaring a client: %v", err)
 	}
 
 	for _, tt := range tests {
@@ -214,9 +214,6 @@ func Test_Do(t *testing.T) {
 				w.Write(resp)
 			}))
 
-			// Close the server when test finishes
-			defer server.Close()
-
 			url, _ := url.ParseRequestURI(server.URL)
 			// tie Requester url and client to the fake server
 			c.BaseURL = url
@@ -225,16 +222,26 @@ func Test_Do(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			req, err := c.NewRequest(ctx, tt.method, tt.path, tt.query, tt.body, tt.header)
+			var bodyReader io.ReadCloser
+			jsonBody, err := json.Marshal(tt.body)
+			if err != nil {
+				t.Fatalf("failed to marshall request body: %v", err)
+			}
+
+			bodyReader = io.NopCloser(bytes.NewReader(jsonBody))
+			req, err := c.NewRequest(ctx, tt.method, tt.path,
+				WithQuery(tt.query),
+				WithBody(bodyReader),
+				WithHeader(tt.header))
+
 			if err != nil {
 				t.Fatalf("request generation failed with error: %v", err)
 			}
 
-			res, resp, err := c.Do(req)
+			res, _, err := c.Do(req)
 			if err != nil {
 				t.Fatalf("request failed with error: %v", err)
 			}
-			defer resp.Body.Close()
 
 			if tt.method == http.MethodGet {
 				user := user{}
@@ -302,13 +309,12 @@ func Test_DoWithRetry(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			request, err := c.NewRequest(ctx, http.MethodGet, "", nil, nil, nil)
+			request, err := c.NewRequest(ctx, http.MethodGet, "")
 			if err != nil {
 				t.Fatalf("failed to create request: %v", err)
 			}
 
-			res, resp, err := c.Do(request)
-			defer resp.Body.Close()
+			res, _, err := c.Do(request)
 			if err != nil {
 				if !strings.Contains(err.Error(), string(tt.output)) {
 					t.Fatalf("request failed: %v", err)

--- a/stash/groups.go
+++ b/stash/groups.go
@@ -71,8 +71,8 @@ func (g *GroupList) GetGroups() []*Group {
 // The authenticated user must have the LICENSED_USER permission to call this resource.
 // https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
 func (s *GroupsService) List(ctx context.Context, opts *PagingOptions) (*GroupList, error) {
-	query := addPaging(&url.Values{}, opts)
-	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupsURI), *query, nil, nil)
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupsURI), WithQuery(query))
 	if err != nil {
 		return nil, fmt.Errorf("list groups failed: , %w", err)
 	}
@@ -81,9 +81,6 @@ func (s *GroupsService) List(ctx context.Context, opts *PagingOptions) (*GroupLi
 		return nil, fmt.Errorf("list groups failed: , %w", err)
 	}
 
-	// As nothing is done with the response body, it is safe to close here
-	// to avoid leaking connections
-	defer resp.Body.Close()
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
@@ -107,11 +104,11 @@ func (s *GroupsService) List(ctx context.Context, opts *PagingOptions) (*GroupLi
 // The authenticated user must have the LICENSED_USER permission to call this resource.
 // https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
 func (s *GroupsService) Get(ctx context.Context, groupName string) (*Group, error) {
-	query := &url.Values{
+	query := url.Values{
 		"filter": []string{groupName},
 	}
 
-	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupsURI), *query, nil, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupsURI), WithQuery(query))
 	if err != nil {
 		return nil, fmt.Errorf("list groups failed: , %w", err)
 	}
@@ -121,9 +118,6 @@ func (s *GroupsService) Get(ctx context.Context, groupName string) (*Group, erro
 		return nil, fmt.Errorf("get group failed: , %w", err)
 	}
 
-	// As nothing is done with the response body, it is safe to close here
-	// to avoid leaking connections
-	defer resp.Body.Close()
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
@@ -162,11 +156,10 @@ func (m *GroupMembers) GetGroupMembers() []*User {
 // The authenticated user must have the LICENSED_USER permission to call this resource.
 // https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
 func (s *GroupsService) ListGroupMembers(ctx context.Context, groupName string, opts *PagingOptions) (*GroupMembers, error) {
-	query := &url.Values{}
-	query = addPaging(query, opts)
+	query := addPaging(url.Values{}, opts)
 	// The group name is required as a parameter
 	query.Set(contextKey, groupName)
-	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupMembersURI), *query, nil, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(groupMembersURI), WithQuery(query))
 	if err != nil {
 		return nil, fmt.Errorf("list groups request creation failed: , %w", err)
 	}
@@ -175,9 +168,6 @@ func (s *GroupsService) ListGroupMembers(ctx context.Context, groupName string, 
 		return nil, fmt.Errorf("list group members failed: , %w", err)
 	}
 
-	// As nothing is done with the response body, it is safe to close here
-	// to avoid leaking connections
-	defer resp.Body.Close()
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}

--- a/stash/projects.go
+++ b/stash/projects.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	projectsURI        = "projects"
+	groupPermisionsURI = "permissions/groups"
+	userPermisionsURI  = "permissions/users"
+)
+
+// Projects interface defines the methods that can be used to
+// retrieve projects and related permissions.
+type Projects interface {
+	List(ctx context.Context, opts *PagingOptions) (*ProjectsList, error)
+	Get(ctx context.Context, projectName string) (*Project, error)
+	ListProjectGroupsPermission(ctx context.Context, projectKey string, opts *PagingOptions) (*ProjectGroups, error)
+	ListProjectUsersPermission(ctx context.Context, projectKey string, opts *PagingOptions) (*ProjectUsers, error)
+}
+
+// ProjectsService is a client for communicating with stash projects endpoint
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+type ProjectsService service
+
+// Project represents a Stash project
+// which is a way for teams to group, manage, and organize their repositories.
+type Project struct {
+	// Session is the http.Response of the last request made to the Stash API.
+	Session `json:"sessionInfo,omitempty"`
+	// Description is the project description.
+	Description string `json:"description,omitempty"`
+	// ID is the project ID.
+	ID int64 `json:"id,omitempty"`
+	// Key is the project key.
+	Key string `json:"key,omitempty"`
+	// Links is the project hyperlinks.
+	Links `json:"links,omitempty"`
+	// User is the the authenticated user.
+	User `json:"owner,omitempty"`
+	// Name is the project name.
+	Name string `json:"name,omitempty"`
+	// Public is the project public flag.
+	Public bool `json:"public,omitempty"`
+	// Type is the project type.
+	Type string `json:"type,omitempty"`
+}
+
+// ProjectsList is a list of projects
+type ProjectsList struct {
+	// Paging is the paging information.
+	Paging
+	// Projects is the list of projects.
+	Projects []*Project `json:"values,omitempty"`
+}
+
+// GetProjects returns a slice of Project.
+func (p *ProjectsList) GetProjects() []*Project {
+	return p.Projects
+}
+
+// List retrieves a list of projects.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a ProjectsList struct is returned. It contains paging information to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/projects".
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *ProjectsService) List(ctx context.Context, opts *PagingOptions) (*ProjectsList, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("get projects request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list projects failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	p := &ProjectsList{
+		Projects: []*Project{},
+	}
+	if err := json.Unmarshal(res, p); err != nil {
+		return nil, fmt.Errorf("list projects failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	for _, r := range p.GetProjects() {
+		r.Session.set(resp)
+	}
+
+	return p, nil
+}
+
+// Get retrieves a project by Name.
+// Get uses the endpoint "GET /rest/api/1.0/projects/{projectKey}".
+// The authenticated user must have PROJECT_VIEW permission for the specified project to call this resource.
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *ProjectsService) Get(ctx context.Context, projectName string) (*Project, error) {
+	query := url.Values{
+		"name": []string{projectName},
+	}
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("get project request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get project failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	p := &Project{}
+	if err := json.Unmarshal(res, &p); err != nil {
+		return nil, fmt.Errorf("get project failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	p.Session.set(resp)
+	return p, nil
+
+}
+
+// ProjectGroupPermission is a permission for a given group.
+// The permission is tied to a project.
+// The permission can be either read, write, or admin.
+type ProjectGroupPermission struct {
+	// Session is the http.Response of the last request made to the Stash API.
+	Session Session `json:"sessionInfo,omitempty"`
+	// Group is the group that the permission is for.
+	Group struct {
+		Name string `json:"name,omitempty"`
+	} `json:"group,omitempty"`
+	// Permission denotes a group's permission level. Available project permissions are:
+	// PROJECT_READ
+	// PROJECT_WRITE
+	// PROJECT_ADMIN
+	Permission string `json:"permission,omitempty"`
+}
+
+// ProjectGroups represents a list of groups for a given project.
+type ProjectGroups struct {
+	// Paging is the paging information.
+	Paging
+	// ProjectKey is the Key of the project.
+	ProjectKey string `json:"-"`
+	// Groups is the list of groups permissions.
+	Groups []*ProjectGroupPermission `json:"values,omitempty"`
+}
+
+// GetGroups returns a slice of ProjectGroupPermission.
+func (p *ProjectGroups) GetGroups() []*ProjectGroupPermission {
+	return p.Groups
+}
+
+// ListProjectGroupsPermission retrieves a list of groups and their permissions for a given project.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a ProjectGroups struct is returned. It contains paging information to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/permissions/groups".
+// The authenticated user must have PROJECT_ADMIN permission for the specified project
+// or a higher global permission to call this resource.
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *ProjectsService) ListProjectGroupsPermission(ctx context.Context, projectKey string, opts *PagingOptions) (*ProjectGroups, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, groupPermisionsURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("get project groups permission request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list project groups permission failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	gp := &ProjectGroups{
+		ProjectKey: projectKey,
+		Groups:     []*ProjectGroupPermission{},
+	}
+	if err := json.Unmarshal(res, gp); err != nil {
+		return nil, fmt.Errorf("list project groups permission failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	for _, r := range gp.GetGroups() {
+		r.Session.set(resp)
+	}
+
+	return gp, nil
+}
+
+// ProjectUserPermission is a permission for a given User.
+// The permission is tied to a project.
+// The permission can be either read, write, or admin.
+type ProjectUserPermission struct {
+	// Session is the http.Response of the last request made to the Stash API.
+	Session Session `json:"sessionInfo,omitempty"`
+	// User is the user that the permission is for.
+	User User `json:"user,omitempty"`
+	// Permission denotes a group's permission level. Available project permissions are:
+	// PROJECT_READ
+	// PROJECT_WRITE
+	// PROJECT_ADMIN
+	Permission string `json:"permission,omitempty"`
+}
+
+// ProjectUsers represents a list of users for a given project.
+type ProjectUsers struct {
+	// Paging is the paging information.
+	Paging
+	// ProjectKey is the key of the project.
+	ProjectKey string `json:"-"`
+	// Users is the list of users permissions.
+	Users []*ProjectUserPermission `json:"values,omitempty"`
+}
+
+// GetUsers returns a slice of ProjectUserPermission.
+func (p *ProjectUsers) GetUsers() []*ProjectUserPermission {
+	return p.Users
+}
+
+// ListProjectUsersPermission retrieves a list of users and their permissions for a given project.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a ProjectUsers struct is returned. It contains paging information to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/permissions/users".
+// The authenticated user must have PROJECT_ADMIN permission for the specified project
+// or a higher global permission to call this resource.
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *ProjectsService) ListProjectUsersPermission(ctx context.Context, projectKey string, opts *PagingOptions) (*ProjectUsers, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, userPermisionsURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("get project users permission request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list project users permission failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	up := &ProjectUsers{
+		ProjectKey: projectKey,
+		Users:      []*ProjectUserPermission{},
+	}
+	if err := json.Unmarshal(res, up); err != nil {
+		return nil, fmt.Errorf("list project users permission failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	for _, r := range up.GetUsers() {
+		r.Session.set(resp)
+	}
+
+	return up, nil
+}

--- a/stash/projects_test.go
+++ b/stash/projects_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetProject(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		output      string
+	}{
+		{
+			name:        "test project does not exist",
+			projectName: "admin",
+		},
+		{
+			name:        "test a project",
+			projectName: "project 1",
+		},
+	}
+
+	validNames := []string{"project1"}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s", stashURIprefix, projectsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		for _, substr := range validNames {
+			if strings.Contains(r.Form.Get("name"), substr) {
+				w.WriteHeader(http.StatusOK)
+				u := &Project{
+					Name: substr,
+				}
+				json.NewEncoder(w).Encode(u)
+				return
+			}
+		}
+
+		http.Error(w, "The specified project does not exist", http.StatusNotFound)
+
+		return
+
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			group, err := client.Projects.Get(ctx, tt.projectName)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Fatalf("Projects.GetProject returned error: %v", err)
+				}
+				return
+			}
+
+			if group.Name != tt.projectName {
+				t.Errorf("Projects.GetProject returned group %s, want %s", group.Name, tt.projectName)
+			}
+
+		})
+	}
+}
+
+func TestListProjects(t *testing.T) {
+	pNames := []*Project{
+		{Name: "project1"}, {Name: "demo"}, {Name: "infra"}, {Name: "app"}}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s", stashURIprefix, projectsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		u := struct {
+			Projects []*Project `json:"values"`
+		}{[]*Project{
+			pNames[0],
+			pNames[1],
+			pNames[2],
+			pNames[3],
+		}}
+		json.NewEncoder(w).Encode(u)
+		return
+
+	})
+	ctx := context.Background()
+	list, err := client.Projects.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("Projects.ProjectList returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(pNames, list.Projects); diff != "" {
+		t.Errorf("Projects.ProjectList returned diff (want -> got):\n%s", diff)
+	}
+
+}
+
+func TestListProjectGroupsPermission(t *testing.T) {
+
+	type group struct {
+		Name string "json:\"name,omitempty\""
+	}
+	tests := []*ProjectGroupPermission{
+		{
+			Group: group{
+				Name: "Reader",
+			},
+			Permission: "PROJECT_READ",
+		},
+		{
+			Group: group{
+				Name: "Writer",
+			},
+			Permission: "PROJECT_WRITE",
+		},
+		{
+			Group: group{
+				Name: "Admin",
+			},
+			Permission: "PROJECT_ADMIN",
+		},
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/projects/testProject/%s", stashURIprefix, groupPermisionsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "testProject") {
+			w.WriteHeader(http.StatusOK)
+			g := struct {
+				Groups []*ProjectGroupPermission `json:"values"`
+			}{
+				[]*ProjectGroupPermission{
+					tests[0],
+					tests[1],
+					tests[2],
+				},
+			}
+
+			json.NewEncoder(w).Encode(g)
+			return
+		}
+	})
+	ctx := context.Background()
+	list, err := client.Projects.ListProjectGroupsPermission(ctx, "testProject", nil)
+	if err != nil {
+		t.Fatalf("Projects.ListProjectGroupsPermission returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(tests, list.Groups); diff != "" {
+		t.Errorf("Projects.ListProjectGroupsPermission returned diff (want -> got):\n%s", diff)
+	}
+}
+
+func TestListProjectUsersPermission(t *testing.T) {
+	tests := []*ProjectUserPermission{
+		{
+			User: User{
+				Slug: "Reader",
+			},
+			Permission: "PROJECT_READ",
+		},
+		{
+			User: User{
+				Slug: "Writer",
+			},
+			Permission: "PROJECT_WRITE",
+		},
+		{
+			User: User{
+				Slug: "Admin",
+			},
+			Permission: "PROJECT_ADMIN",
+		},
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/projects/testProject/%s", stashURIprefix, userPermisionsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "testProject") {
+			w.WriteHeader(http.StatusOK)
+			g := struct {
+				Groups []*ProjectUserPermission `json:"values"`
+			}{
+				[]*ProjectUserPermission{
+					tests[0],
+					tests[1],
+					tests[2],
+				},
+			}
+
+			json.NewEncoder(w).Encode(g)
+			return
+		}
+	})
+	ctx := context.Background()
+	list, err := client.Projects.ListProjectUsersPermission(ctx, "testProject", nil)
+	if err != nil {
+		t.Fatalf("Projects.ListProjectUsersPermission returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(tests, list.Users); diff != "" {
+		t.Errorf("Projects.ListProjectUsersPermission returned diff (want -> got):\n%s", diff)
+	}
+
+}

--- a/stash/users.go
+++ b/stash/users.go
@@ -96,9 +96,8 @@ func (u *UserList) GetUsers() []*User {
 // A pointer to a paging struct is returned to retrieve the next page of results.
 // List uses the endpoint "GET /rest/api/1.0/users".
 func (s *UsersService) List(ctx context.Context, opts *PagingOptions) (*UserList, error) {
-	var query *url.Values
-	query = addPaging(query, opts)
-	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(usersURI), *query, nil, nil)
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(usersURI), WithQuery(query))
 	if err != nil {
 		return nil, fmt.Errorf("list users request creation failed, %w", err)
 	}
@@ -107,10 +106,6 @@ func (s *UsersService) List(ctx context.Context, opts *PagingOptions) (*UserList
 	if err != nil {
 		return nil, fmt.Errorf("list users failed, %w", err)
 	}
-
-	// As nothing is done with the response body, it is safe to close here
-	// to avoid leaking connections
-	defer resp.Body.Close()
 
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
@@ -133,9 +128,7 @@ func (s *UsersService) List(ctx context.Context, opts *PagingOptions) (*UserList
 // Get retrieves a user by name.
 // Get uses the endpoint "GET /rest/api/1.0/users/{userSlug}".
 func (s *UsersService) Get(ctx context.Context, userSlug string) (*User, error) {
-	var query *url.Values
-	query = addPaging(query, &PagingOptions{})
-	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(usersURI, userSlug), *query, nil, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(usersURI, userSlug))
 	if err != nil {
 		return nil, fmt.Errorf("get user request creation failed, %w", err)
 	}
@@ -143,10 +136,6 @@ func (s *UsersService) Get(ctx context.Context, userSlug string) (*User, error) 
 	if err != nil {
 		return nil, fmt.Errorf("get user failed, %w", err)
 	}
-
-	// As nothing is done with the response body, it is safe to close here
-	// to avoid leaking connections
-	defer resp.Body.Close()
 
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
@@ -164,9 +153,9 @@ func (s *UsersService) Get(ctx context.Context, userSlug string) (*User, error) 
 }
 
 // addPaging adds paging elements to URI query
-func addPaging(query *url.Values, opts *PagingOptions) *url.Values {
+func addPaging(query url.Values, opts *PagingOptions) url.Values {
 	if query == nil {
-		query = &url.Values{}
+		query = url.Values{}
 	}
 
 	if opts == nil {


### PR DESCRIPTION
#102 

Signed-off-by: Soule BA <soule@weave.works>

### Description

ProjectsService permits retrieving projects and listing them.

It permits as well retrieving a given project's users and groups with permissions.


### Test results

https://github.com/souleb/go-git-providers/actions/runs/1229612646
