### PR TITLE
Add PR List, Get and Merge support for GitHub and GitLab

### DIFF
--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -32,6 +32,22 @@ type PullRequestClient struct {
 	ref gitprovider.RepositoryRef
 }
 
+// List lists all pull requests in the repository
+func (c *PullRequestClient) List(ctx context.Context) ([]gitprovider.PullRequest, error) {
+	prs, _, err := c.c.Client().PullRequests.List(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	requests := make([]gitprovider.PullRequest, len(prs))
+
+	for idx, pr := range prs {
+		requests[idx] = newPullRequest(c.clientContext, pr)
+	}
+
+	return requests, nil
+}
+
 // Create creates a pull request with the given specifications.
 func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranch, description string) (gitprovider.PullRequest, error) {
 

--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -49,3 +49,31 @@ func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranc
 
 	return newPullRequest(c.clientContext, pr), nil
 }
+
+// Get retrieves an existing pull request by number
+func (c *PullRequestClient) Get(ctx context.Context, number int) (gitprovider.PullRequest, error) {
+
+	pr, _, err := c.c.Client().PullRequests.Get(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), number)
+	if err != nil {
+		return nil, err
+	}
+
+	return newPullRequest(c.clientContext, pr), nil
+}
+
+// Merge merges a pull request with the given specifications.
+func (c *PullRequestClient) Merge(ctx context.Context, number int, mergeMethod gitprovider.MergeMethod, message string) error {
+
+	prOpts := &github.PullRequestOptions{
+		CommitTitle: "",
+		SHA:         "",
+		MergeMethod: string(mergeMethod),
+	}
+
+	_, _, err := c.c.Client().PullRequests.Merge(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), number, message, prOpts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -478,6 +478,10 @@ var _ = Describe("GitHub Provider", func() {
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 		Expect(pr.Get().Merged).To(BeFalse())
 
+		prs, err := userRepo.PullRequests().List(ctx)
+		Expect(len(prs)).To(Equal(1))
+		Expect(prs[0].Get().WebURL).To(Equal(pr.Get().WebURL))
+
 		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodSquash, "squash merged")
 		Expect(err).ToNot(HaveOccurred())
 

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -476,6 +476,40 @@ var _ = Describe("GitHub Provider", func() {
 		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, *defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+		Expect(pr.Get().Merged).To(BeFalse())
+
+		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodSquash, "squash merged")
+		Expect(err).ToNot(HaveOccurred())
+
+		getPR, err := userRepo.PullRequests().Get(ctx, pr.Get().Number)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(getPR.Get().Merged).To(BeTrue())
+
+		path = "setup/config2.txt"
+		content = "yaml content"
+		files = []gitprovider.CommitFile{
+			gitprovider.CommitFile{
+				Path:    &path,
+				Content: &content,
+			},
+		}
+
+		_, err = userRepo.Commits().Create(ctx, branchName, "added second config file", files)
+		Expect(err).ToNot(HaveOccurred())
+
+		pr, err = userRepo.PullRequests().Create(ctx, "Added second config file", branchName, *defaultBranch, "added second config file")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+		Expect(pr.Get().Merged).To(BeFalse())
+
+		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodMerge, "merged")
+		Expect(err).ToNot(HaveOccurred())
+
+		getPR, err = userRepo.PullRequests().Get(ctx, pr.Get().Number)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(getPR.Get().Merged).To(BeTrue())
 	})
 
 	AfterSuite(func() {

--- a/github/resource_pullrequest.go
+++ b/github/resource_pullrequest.go
@@ -46,6 +46,8 @@ func (pr *pullrequest) APIObject() interface{} {
 
 func pullrequestFromAPI(apiObj *github.PullRequest) gitprovider.PullRequestInfo {
 	return gitprovider.PullRequestInfo{
+		Merged: apiObj.GetMerged(),
+		Number: apiObj.GetNumber(),
 		WebURL: apiObj.GetHTMLURL(),
 	}
 }

--- a/gitlab/client_repository_pullrequest.go
+++ b/gitlab/client_repository_pullrequest.go
@@ -37,6 +37,22 @@ type PullRequestClient struct {
 	ref gitprovider.RepositoryRef
 }
 
+// List lists all pull requests in the repository
+func (c *PullRequestClient) List(ctx context.Context) ([]gitprovider.PullRequest, error) {
+	mrs, _, err := c.c.Client().MergeRequests.ListMergeRequests(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	requests := make([]gitprovider.PullRequest, len(mrs))
+
+	for idx, mr := range mrs {
+		requests[idx] = newPullRequest(c.clientContext, mr)
+	}
+
+	return requests, nil
+}
+
 // Create creates a pull request with the given specifications.
 func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranch, description string) (gitprovider.PullRequest, error) {
 

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -785,6 +785,11 @@ var _ = Describe("GitLab Provider", func() {
 
 		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
+
+		prs, err := userRepo.PullRequests().List(ctx)
+		Expect(len(prs)).To(Equal(1))
+		Expect(prs[0].Get().WebURL).To(Equal(pr.Get().WebURL))
+
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 		Expect(pr.Get().Merged).To(BeFalse())
 		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodSquash, "squash merged")

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -786,6 +786,39 @@ var _ = Describe("GitLab Provider", func() {
 		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+		Expect(pr.Get().Merged).To(BeFalse())
+		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodSquash, "squash merged")
+		Expect(err).ToNot(HaveOccurred())
+
+		getPR, err := userRepo.PullRequests().Get(ctx, pr.Get().Number)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(getPR.Get().Merged).To(BeTrue())
+
+		path = "setup/config2.txt"
+		content = "yaml content"
+		files = []gitprovider.CommitFile{
+			gitprovider.CommitFile{
+				Path:    &path,
+				Content: &content,
+			},
+		}
+
+		_, err = userRepo.Commits().Create(ctx, branchName, "added second config file", files)
+		Expect(err).ToNot(HaveOccurred())
+
+		pr, err = userRepo.PullRequests().Create(ctx, "Added second config file", branchName, defaultBranch, "added second config file")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+		Expect(pr.Get().Merged).To(BeFalse())
+
+		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodMerge, "merged")
+		Expect(err).ToNot(HaveOccurred())
+
+		getPR, err = userRepo.PullRequests().Get(ctx, pr.Get().Number)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(getPR.Get().Merged).To(BeTrue())
 	})
 
 	AfterSuite(func() {

--- a/gitlab/resource_pullrequest.go
+++ b/gitlab/resource_pullrequest.go
@@ -21,6 +21,9 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
+// The value of the "State" field of a gitlab merge request after it has been merged"
+const mergedState = "merged"
+
 func newPullRequest(ctx *clientContext, apiObj *gitlab.MergeRequest) *pullrequest {
 	return &pullrequest{
 		clientContext: ctx,
@@ -46,6 +49,8 @@ func (pr *pullrequest) APIObject() interface{} {
 
 func pullrequestFromAPI(apiObj *gitlab.MergeRequest) gitprovider.PullRequestInfo {
 	return gitprovider.PullRequestInfo{
+		Merged: apiObj.State == mergedState,
+		Number: apiObj.IID,
 		WebURL: apiObj.WebURL,
 	}
 }

--- a/gitprovider/client.go
+++ b/gitprovider/client.go
@@ -229,4 +229,8 @@ type BranchClient interface {
 type PullRequestClient interface {
 	// Create creates a pull request with the given specifications.
 	Create(ctx context.Context, title, branch, baseBranch, description string) (PullRequest, error)
+	// Get retrieves an existing pull request by number
+	Get(ctx context.Context, number int) (PullRequest, error)
+	// Merge merges a pull request with via either the "Squash" or "Merge" method
+	Merge(ctx context.Context, number int, mergeMethod MergeMethod, message string) error
 }

--- a/gitprovider/client.go
+++ b/gitprovider/client.go
@@ -227,6 +227,8 @@ type BranchClient interface {
 // PullRequestClient operates on the pull requests for a specific repository.
 // This client can be accessed through Repository.PullRequests().
 type PullRequestClient interface {
+	// List lists all pull requests in the repository
+	List(ctx context.Context) ([]PullRequest, error)
 	// Create creates a pull request with the given specifications.
 	Create(ctx context.Context, title, branch, baseBranch, description string) (PullRequest, error)
 	// Get retrieves an existing pull request by number

--- a/gitprovider/enums.go
+++ b/gitprovider/enums.go
@@ -168,3 +168,13 @@ const (
 	// Read/Write permission for public/private repositories.
 	TokenPermissionRWRepository TokenPermission = iota + 1
 )
+
+type MergeMethod string
+
+const (
+	// MergeMethodMerge causes a pull request merge to create a simple merge commit
+	MergeMethodMerge = MergeMethod("merge")
+
+	// MergeMethodMerge causes a pull request merge to first squash commits
+	MergeMethodSquash = MergeMethod("squash")
+)

--- a/gitprovider/types_repository.go
+++ b/gitprovider/types_repository.go
@@ -214,6 +214,12 @@ type CommitFile struct {
 }
 
 type PullRequestInfo struct {
+	// Merged specifes whether or not this pull request has been merged
+	Merged bool `json:"merged"`
+
+	// Number is the number of the pull request that can be used to merge
+	Number int `json:"number"`
+
 	// WebURL is the URL of the pull request in the git provider web interface.
 	// +required
 	WebURL string `json:"web_url"`


### PR DESCRIPTION
Signed-off-by: Jerry Jackson <jrryjcksn@gmail.com>

### Description
Adds support for listing, getting, and merging pull requests in GitHub and GitLab. `Merge` and `Squash` options are supported for merge.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
-->
- Added `List()`, `Get()`, and `Merge()` operations for pull requests in `GitHub` and merge requests in `GitLab`. 
- Extended the `gitprovider.PullRequestInfo` struct to contain `Number` (id of pull request) and `Merged` (whether or not the PR has been merged)
- Added a `gitprovider.MergeMethod` enum with values for `merge` and `squash`
- Extended the integration tests to perform both merge variations for both providers

Due to GitLab's asynchronous merge status updating, the `GitLab` `Merge()` polls for MergeStatus to be updated from "checking" (up to 20 seconds) before giving up. See: https://gitlab.com/gitlab-org/gitlab/-/issues/196962

### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
```
arete: ~jj/go-git-providers> CGO_ENABLED=1 make test
go mod tidy
go fmt ./...
go vet ./...
go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
?   	github.com/fluxcd/go-git-providers/bitbucket	[no test files]
=== RUN   Test_DomainVariations
=== RUN   Test_DomainVariations/github.com_domain
=== RUN   Test_DomainVariations/custom_domain_without_protocol
=== RUN   Test_DomainVariations/custom_domain_with_https_protocol
=== RUN   Test_DomainVariations/custom_domain_with_http_protocol
--- PASS: Test_DomainVariations (0.00s)
    --- PASS: Test_DomainVariations/github.com_domain (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_without_protocol (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_with_https_protocol (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_with_http_protocol (0.00s)
=== RUN   TestProvider
Running Suite: GitHub Provider Suite
====================================
Random Seed: 1633113297
Will run 8 of 8 specs

•••••••
------------------------------
• [SLOW TEST:6.720 seconds]
GitHub Provider
/home/jerry/src/github.com/jrryjcksn/go-git-providers/github/integration_test.go:129
  should be possible to create a pr for a user repository
  /home/jerry/src/github.com/jrryjcksn/go-git-providers/github/integration_test.go:429
------------------------------
Deleting repos starting with test-repo for user: jrryjcksn
<many repos skipped...>
Deleting repos starting with test-repo in org: jrryjcksn-org
Deleting the org repo: test-repo-091

Ran 8 of 8 Specs in 16.962 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestProvider (16.97s)
=== RUN   Test_getPermissionFromMap
=== RUN   Test_getPermissionFromMap/pull
=== RUN   Test_getPermissionFromMap/push
=== RUN   Test_getPermissionFromMap/admin
=== RUN   Test_getPermissionFromMap/none
=== RUN   Test_getPermissionFromMap/false_data
=== RUN   Test_getPermissionFromMap/not_all_specifed
--- PASS: Test_getPermissionFromMap (0.00s)
    --- PASS: Test_getPermissionFromMap/pull (0.00s)
    --- PASS: Test_getPermissionFromMap/push (0.00s)
    --- PASS: Test_getPermissionFromMap/admin (0.00s)
    --- PASS: Test_getPermissionFromMap/none (0.00s)
    --- PASS: Test_getPermissionFromMap/false_data (0.00s)
    --- PASS: Test_getPermissionFromMap/not_all_specifed (0.00s)
=== RUN   Test_validateAPIObject
=== RUN   Test_validateAPIObject/no_error_=>_nil
=== RUN   Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData
--- PASS: Test_validateAPIObject (0.00s)
    --- PASS: Test_validateAPIObject/no_error_=>_nil (0.00s)
    --- PASS: Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData (0.00s)
=== RUN   Test_allPages
=== RUN   Test_allPages/one_page_only,_no_error
=== RUN   Test_allPages/two_pages,_no_error
=== RUN   Test_allPages/four_pages,_error_at_second
--- PASS: Test_allPages (0.00s)
    --- PASS: Test_allPages/one_page_only,_no_error (0.00s)
    --- PASS: Test_allPages/two_pages,_no_error (0.00s)
    --- PASS: Test_allPages/four_pages,_error_at_second (0.00s)
=== RUN   ExampleOrganizationsClient_Get
--- PASS: ExampleOrganizationsClient_Get (0.10s)
=== RUN   ExampleOrgRepositoriesClient_Get
--- PASS: ExampleOrgRepositoriesClient_Get (0.67s)
PASS
coverage: 49.1% of statements
ok  	github.com/fluxcd/go-git-providers/github	17.769s	coverage: 49.1% of statements
=== RUN   Test_DomainVariations
=== RUN   Test_DomainVariations/gitlab.com_domain
=== RUN   Test_DomainVariations/custom_domain_without_protocol
=== RUN   Test_DomainVariations/custom_domain_with_https_protocol
=== RUN   Test_DomainVariations/custom_domain_with_http_protocol
--- PASS: Test_DomainVariations (0.00s)
    --- PASS: Test_DomainVariations/gitlab.com_domain (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_without_protocol (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_with_https_protocol (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_with_http_protocol (0.00s)
=== RUN   TestProvider
Running Suite: GitLab Provider Suite
====================================
Random Seed: 1633113297
Will run 11 of 11 specs

••validating repo: test-org-repo-426
••validating repo: test-org-repo-426

------------------------------
• [SLOW TEST:5.209 seconds]
GitLab Provider
/home/jerry/src/github.com/jrryjcksn/go-git-providers/gitlab/integration_test.go:172
  should update if the org repo already exists when reconciling
  /home/jerry/src/github.com/jrryjcksn/go-git-providers/gitlab/integration_test.go:395
------------------------------
validating repo: test-shared-org-repo-480
• [SLOW TEST:11.144 seconds]
GitLab Provider
/home/jerry/src/github.com/jrryjcksn/go-git-providers/gitlab/integration_test.go:172
  should update teams with access and permissions when reconciling
  /home/jerry/src/github.com/jrryjcksn/go-git-providers/gitlab/integration_test.go:443
------------------------------
••••
------------------------------
• [SLOW TEST:18.283 seconds]
GitLab Provider
/home/jerry/src/github.com/jrryjcksn/go-git-providers/gitlab/integration_test.go:172
  should be possible to create a pr for a user repository
  /home/jerry/src/github.com/jrryjcksn/go-git-providers/gitlab/integration_test.go:733
------------------------------
Deleting the user repo:  test-repo2-704
Deleting the org repo:  test-org-repo-426
Deleting the shared org repo:  test-shared-org-repo-480
Deleting repos starting with test-repo for user: jrryjcksn
Deleting the org repo: test-repo-946
Deleting repos starting with test-shared-org-repo in org: jrryjcksn-org
Deleting repos starting with test-org-repo in org: jrryjcksn-org

Ran 11 of 11 Specs in 50.169 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestProvider (50.17s)
=== RUN   Test_getGitProviderPermission
=== RUN   Test_getGitProviderPermission/pull
=== RUN   Test_getGitProviderPermission/push
=== RUN   Test_getGitProviderPermission/admin
=== RUN   Test_getGitProviderPermission/false_data
--- PASS: Test_getGitProviderPermission (0.00s)
    --- PASS: Test_getGitProviderPermission/pull (0.00s)
    --- PASS: Test_getGitProviderPermission/push (0.00s)
    --- PASS: Test_getGitProviderPermission/admin (0.00s)
    --- PASS: Test_getGitProviderPermission/false_data (0.00s)
=== RUN   Test_getGitlabPermission
=== RUN   Test_getGitlabPermission/pull
=== RUN   Test_getGitlabPermission/push
=== RUN   Test_getGitlabPermission/admin
--- PASS: Test_getGitlabPermission (0.00s)
    --- PASS: Test_getGitlabPermission/pull (0.00s)
    --- PASS: Test_getGitlabPermission/push (0.00s)
    --- PASS: Test_getGitlabPermission/admin (0.00s)
=== RUN   Test_validateAPIObject
=== RUN   Test_validateAPIObject/no_error_=>_nil
=== RUN   Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData
--- PASS: Test_validateAPIObject (0.00s)
    --- PASS: Test_validateAPIObject/no_error_=>_nil (0.00s)
    --- PASS: Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData (0.00s)
=== RUN   Test_allGroupPages
=== RUN   Test_allGroupPages/one_page_only,_no_error
=== RUN   Test_allGroupPages/two_pages,_no_error
=== RUN   Test_allGroupPages/four_pages,_error_at_second
--- PASS: Test_allGroupPages (0.00s)
    --- PASS: Test_allGroupPages/one_page_only,_no_error (0.00s)
    --- PASS: Test_allGroupPages/two_pages,_no_error (0.00s)
    --- PASS: Test_allGroupPages/four_pages,_error_at_second (0.00s)
=== RUN   TestExampleOrganizationsClient_Get
Name: fluxcd-testing-public. Location: fluxcd-testing-public.--- PASS: TestExampleOrganizationsClient_Get (0.41s)
=== RUN   ExampleOrgRepositoriesClient_Get
--- PASS: ExampleOrgRepositoriesClient_Get (0.34s)
PASS
coverage: 73.1% of statements
ok  	github.com/fluxcd/go-git-providers/gitlab	50.957s	coverage: 73.1% of statements
=== RUN   Test_makeOptions
=== RUN   Test_makeOptions/no_options
=== RUN   Test_makeOptions/withDomain
=== RUN   Test_makeOptions/withDomain,_empty
=== RUN   Test_makeOptions/withDomain,_duplicate
=== RUN   Test_makeOptions/withDestructiveAPICalls
=== RUN   Test_makeOptions/withDestructiveAPICalls,_duplicate
=== RUN   Test_makeOptions/withPreChainTransportHook
=== RUN   Test_makeOptions/withPreChainTransportHook,_duplicate
=== RUN   Test_makeOptions/withPostChainTransportHook
=== RUN   Test_makeOptions/withPostChainTransportHook,_duplicate
--- PASS: Test_makeOptions (0.00s)
    --- PASS: Test_makeOptions/no_options (0.00s)
    --- PASS: Test_makeOptions/withDomain (0.00s)
    --- PASS: Test_makeOptions/withDomain,_empty (0.00s)
    --- PASS: Test_makeOptions/withDomain,_duplicate (0.00s)
    --- PASS: Test_makeOptions/withDestructiveAPICalls (0.00s)
    --- PASS: Test_makeOptions/withDestructiveAPICalls,_duplicate (0.00s)
    --- PASS: Test_makeOptions/withPreChainTransportHook (0.00s)
    --- PASS: Test_makeOptions/withPreChainTransportHook,_duplicate (0.00s)
    --- PASS: Test_makeOptions/withPostChainTransportHook (0.00s)
    --- PASS: Test_makeOptions/withPostChainTransportHook,_duplicate (0.00s)
=== RUN   Test_clientOptions_getTransportChain
=== RUN   Test_clientOptions_getTransportChain/all_roundtrippers
=== RUN   Test_clientOptions_getTransportChain/only_pre_+_auth
=== RUN   Test_clientOptions_getTransportChain/only_cache_+_auth
--- PASS: Test_clientOptions_getTransportChain (0.00s)
    --- PASS: Test_clientOptions_getTransportChain/all_roundtrippers (0.00s)
    --- PASS: Test_clientOptions_getTransportChain/only_pre_+_auth (0.00s)
    --- PASS: Test_clientOptions_getTransportChain/only_cache_+_auth (0.00s)
=== RUN   Test_makeCientOptions
=== RUN   Test_makeCientOptions/no_options
=== RUN   Test_makeCientOptions/WithDomain
=== RUN   Test_makeCientOptions/WithDomain,_empty
=== RUN   Test_makeCientOptions/WithDestructiveAPICalls
=== RUN   Test_makeCientOptions/WithPreChainTransportHook
=== RUN   Test_makeCientOptions/WithPreChainTransportHook,_nil
=== RUN   Test_makeCientOptions/WithPostChainTransportHook
=== RUN   Test_makeCientOptions/WithPostChainTransportHook,_nil
=== RUN   Test_makeCientOptions/WithOAuth2Token
=== RUN   Test_makeCientOptions/WithOAuth2Token,_empty
=== RUN   Test_makeCientOptions/WithConditionalRequests
=== RUN   Test_makeCientOptions/WithConditionalRequests,_exclusive
--- PASS: Test_makeCientOptions (0.00s)
    --- PASS: Test_makeCientOptions/no_options (0.00s)
    --- PASS: Test_makeCientOptions/WithDomain (0.00s)
    --- PASS: Test_makeCientOptions/WithDomain,_empty (0.00s)
    --- PASS: Test_makeCientOptions/WithDestructiveAPICalls (0.00s)
    --- PASS: Test_makeCientOptions/WithPreChainTransportHook (0.00s)
    --- PASS: Test_makeCientOptions/WithPreChainTransportHook,_nil (0.00s)
    --- PASS: Test_makeCientOptions/WithPostChainTransportHook (0.00s)
    --- PASS: Test_makeCientOptions/WithPostChainTransportHook,_nil (0.00s)
    --- PASS: Test_makeCientOptions/WithOAuth2Token (0.00s)
    --- PASS: Test_makeCientOptions/WithOAuth2Token,_empty (0.00s)
    --- PASS: Test_makeCientOptions/WithConditionalRequests (0.00s)
    --- PASS: Test_makeCientOptions/WithConditionalRequests,_exclusive (0.00s)
=== RUN   TestValidateAndDefaultInfo
=== RUN   TestValidateAndDefaultInfo/valid_=>_defaulting
=== RUN   TestValidateAndDefaultInfo/invalid_=>_no_defaulting_+_error
--- PASS: TestValidateAndDefaultInfo (0.00s)
    --- PASS: TestValidateAndDefaultInfo/valid_=>_defaulting (0.00s)
    --- PASS: TestValidateAndDefaultInfo/invalid_=>_no_defaulting_+_error (0.00s)
=== RUN   TestMakeRepositoryCreateOptions
=== RUN   TestMakeRepositoryCreateOptions/default_nil_pointers
=== RUN   TestMakeRepositoryCreateOptions/set_all_fields
=== RUN   TestMakeRepositoryCreateOptions/latter_overrides_former
=== RUN   TestMakeRepositoryCreateOptions/invalid_license_template
=== RUN   TestMakeRepositoryCreateOptions/partial_options_can_form_an_unit
--- PASS: TestMakeRepositoryCreateOptions (0.00s)
    --- PASS: TestMakeRepositoryCreateOptions/default_nil_pointers (0.00s)
    --- PASS: TestMakeRepositoryCreateOptions/set_all_fields (0.00s)
    --- PASS: TestMakeRepositoryCreateOptions/latter_overrides_former (0.00s)
    --- PASS: TestMakeRepositoryCreateOptions/invalid_license_template (0.00s)
    --- PASS: TestMakeRepositoryCreateOptions/partial_options_can_form_an_unit (0.00s)
=== RUN   TestParseOrganizationURL
=== RUN   TestParseOrganizationURL/easy
=== RUN   TestParseOrganizationURL/trailing_slash
=== RUN   TestParseOrganizationURL/one_sub-org
=== RUN   TestParseOrganizationURL/three_sub-orgs_and_custom_domain
=== RUN   TestParseOrganizationURL/no_org_specified
=== RUN   TestParseOrganizationURL/no_org_specified,_trailing_slash
=== RUN   TestParseOrganizationURL/empty_parts_1
=== RUN   TestParseOrganizationURL/empty_parts_2
=== RUN   TestParseOrganizationURL/empty_URL
=== RUN   TestParseOrganizationURL/disallow_fragments
=== RUN   TestParseOrganizationURL/disallow_query_values
=== RUN   TestParseOrganizationURL/disallow_user_auth
=== RUN   TestParseOrganizationURL/disallow_http
=== RUN   TestParseOrganizationURL/no_scheme
=== RUN   TestParseOrganizationURL/invalid_URL
--- PASS: TestParseOrganizationURL (0.00s)
    --- PASS: TestParseOrganizationURL/easy (0.00s)
    --- PASS: TestParseOrganizationURL/trailing_slash (0.00s)
    --- PASS: TestParseOrganizationURL/one_sub-org (0.00s)
    --- PASS: TestParseOrganizationURL/three_sub-orgs_and_custom_domain (0.00s)
    --- PASS: TestParseOrganizationURL/no_org_specified (0.00s)
    --- PASS: TestParseOrganizationURL/no_org_specified,_trailing_slash (0.00s)
    --- PASS: TestParseOrganizationURL/empty_parts_1 (0.00s)
    --- PASS: TestParseOrganizationURL/empty_parts_2 (0.00s)
    --- PASS: TestParseOrganizationURL/empty_URL (0.00s)
    --- PASS: TestParseOrganizationURL/disallow_fragments (0.00s)
    --- PASS: TestParseOrganizationURL/disallow_query_values (0.00s)
    --- PASS: TestParseOrganizationURL/disallow_user_auth (0.00s)
    --- PASS: TestParseOrganizationURL/disallow_http (0.00s)
    --- PASS: TestParseOrganizationURL/no_scheme (0.00s)
    --- PASS: TestParseOrganizationURL/invalid_URL (0.00s)
=== RUN   TestParseUserURL
=== RUN   TestParseUserURL/easy
=== RUN   TestParseUserURL/trailing_slash
=== RUN   TestParseUserURL/custom_domain
=== RUN   TestParseUserURL/can't_have_sub-orgs
=== RUN   TestParseUserURL/no_user_specified
=== RUN   TestParseUserURL/no_user_specified,_trailing_slash
=== RUN   TestParseUserURL/empty_parts_1
=== RUN   TestParseUserURL/empty_parts_2
=== RUN   TestParseUserURL/empty_URL
=== RUN   TestParseUserURL/disallow_fragments
=== RUN   TestParseUserURL/disallow_query_values
=== RUN   TestParseUserURL/disallow_user_auth
=== RUN   TestParseUserURL/disallow_http
=== RUN   TestParseUserURL/no_scheme
=== RUN   TestParseUserURL/invalid_URL
--- PASS: TestParseUserURL (0.00s)
    --- PASS: TestParseUserURL/easy (0.00s)
    --- PASS: TestParseUserURL/trailing_slash (0.00s)
    --- PASS: TestParseUserURL/custom_domain (0.00s)
    --- PASS: TestParseUserURL/can't_have_sub-orgs (0.00s)
    --- PASS: TestParseUserURL/no_user_specified (0.00s)
    --- PASS: TestParseUserURL/no_user_specified,_trailing_slash (0.00s)
    --- PASS: TestParseUserURL/empty_parts_1 (0.00s)
    --- PASS: TestParseUserURL/empty_parts_2 (0.00s)
    --- PASS: TestParseUserURL/empty_URL (0.00s)
    --- PASS: TestParseUserURL/disallow_fragments (0.00s)
    --- PASS: TestParseUserURL/disallow_query_values (0.00s)
    --- PASS: TestParseUserURL/disallow_user_auth (0.00s)
    --- PASS: TestParseUserURL/disallow_http (0.00s)
    --- PASS: TestParseUserURL/no_scheme (0.00s)
    --- PASS: TestParseUserURL/invalid_URL (0.00s)
=== RUN   TestParseRepositoryURL
=== RUN   TestParseRepositoryURL/easy
=== RUN   TestParseRepositoryURL/trailing_slash
=== RUN   TestParseRepositoryURL/including_a_dot
=== RUN   TestParseRepositoryURL/strip_git_suffix
=== RUN   TestParseRepositoryURL/user,_one_sub-org
=== RUN   TestParseRepositoryURL/organization,_one_sub-org
=== RUN   TestParseRepositoryURL/user,_three_sub-orgs_and_custom_domain
=== RUN   TestParseRepositoryURL/organization,_three_sub-orgs_and_custom_domain
=== RUN   TestParseRepositoryURL/no_repo_specified
=== RUN   TestParseRepositoryURL/no_repo_specified,_trailing_slash
=== RUN   TestParseRepositoryURL/empty_parts_1
=== RUN   TestParseRepositoryURL/empty_parts_2
=== RUN   TestParseRepositoryURL/empty_URL
=== RUN   TestParseRepositoryURL/disallow_fragments
=== RUN   TestParseRepositoryURL/disallow_query_values
=== RUN   TestParseRepositoryURL/disallow_user_auth
=== RUN   TestParseRepositoryURL/disallow_http
=== RUN   TestParseRepositoryURL/no_scheme
=== RUN   TestParseRepositoryURL/invalid_URL
--- PASS: TestParseRepositoryURL (0.00s)
    --- PASS: TestParseRepositoryURL/easy (0.00s)
    --- PASS: TestParseRepositoryURL/trailing_slash (0.00s)
    --- PASS: TestParseRepositoryURL/including_a_dot (0.00s)
    --- PASS: TestParseRepositoryURL/strip_git_suffix (0.00s)
    --- PASS: TestParseRepositoryURL/user,_one_sub-org (0.00s)
    --- PASS: TestParseRepositoryURL/organization,_one_sub-org (0.00s)
    --- PASS: TestParseRepositoryURL/user,_three_sub-orgs_and_custom_domain (0.00s)
    --- PASS: TestParseRepositoryURL/organization,_three_sub-orgs_and_custom_domain (0.00s)
    --- PASS: TestParseRepositoryURL/no_repo_specified (0.00s)
    --- PASS: TestParseRepositoryURL/no_repo_specified,_trailing_slash (0.00s)
    --- PASS: TestParseRepositoryURL/empty_parts_1 (0.00s)
    --- PASS: TestParseRepositoryURL/empty_parts_2 (0.00s)
    --- PASS: TestParseRepositoryURL/empty_URL (0.00s)
    --- PASS: TestParseRepositoryURL/disallow_fragments (0.00s)
    --- PASS: TestParseRepositoryURL/disallow_query_values (0.00s)
    --- PASS: TestParseRepositoryURL/disallow_user_auth (0.00s)
    --- PASS: TestParseRepositoryURL/disallow_http (0.00s)
    --- PASS: TestParseRepositoryURL/no_scheme (0.00s)
    --- PASS: TestParseRepositoryURL/invalid_URL (0.00s)
=== RUN   TestGetCloneURL
=== RUN   TestGetCloneURL/org:_https
=== RUN   TestGetCloneURL/org:_git
=== RUN   TestGetCloneURL/org:_ssh
=== RUN   TestGetCloneURL/org:_none
=== RUN   TestGetCloneURL/user:_https
=== RUN   TestGetCloneURL/org:_ssh#01
=== RUN   TestGetCloneURL/org:_ssh#02
=== RUN   TestGetCloneURL/org:_ssh#03
=== RUN   TestGetCloneURL/org:_ssh#04
=== RUN   TestGetCloneURL/user:_git
=== RUN   TestGetCloneURL/user:_ssh
=== RUN   TestGetCloneURL/user:_none
--- PASS: TestGetCloneURL (0.00s)
    --- PASS: TestGetCloneURL/org:_https (0.00s)
    --- PASS: TestGetCloneURL/org:_git (0.00s)
    --- PASS: TestGetCloneURL/org:_ssh (0.00s)
    --- PASS: TestGetCloneURL/org:_none (0.00s)
    --- PASS: TestGetCloneURL/user:_https (0.00s)
    --- PASS: TestGetCloneURL/org:_ssh#01 (0.00s)
    --- PASS: TestGetCloneURL/org:_ssh#02 (0.00s)
    --- PASS: TestGetCloneURL/org:_ssh#03 (0.00s)
    --- PASS: TestGetCloneURL/org:_ssh#04 (0.00s)
    --- PASS: TestGetCloneURL/user:_git (0.00s)
    --- PASS: TestGetCloneURL/user:_ssh (0.00s)
    --- PASS: TestGetCloneURL/user:_none (0.00s)
=== RUN   TestIdentityRef_GetType
=== RUN   TestIdentityRef_GetType/sample_user
=== RUN   TestIdentityRef_GetType/sample_top-level_org
=== RUN   TestIdentityRef_GetType/sample_sub-org
--- PASS: TestIdentityRef_GetType (0.00s)
    --- PASS: TestIdentityRef_GetType/sample_user (0.00s)
    --- PASS: TestIdentityRef_GetType/sample_top-level_org (0.00s)
    --- PASS: TestIdentityRef_GetType/sample_sub-org (0.00s)
=== RUN   TestRepositoryRef_ValidateFields
=== RUN   TestRepositoryRef_ValidateFields/valid_user
=== RUN   TestRepositoryRef_ValidateFields/valid_org
=== RUN   TestRepositoryRef_ValidateFields/valid_sub-org
=== RUN   TestRepositoryRef_ValidateFields/missing_user_reponame
=== RUN   TestRepositoryRef_ValidateFields/missing_user_login
=== RUN   TestRepositoryRef_ValidateFields/missing_user_login#01
=== RUN   TestRepositoryRef_ValidateFields/missing_user_domain
=== RUN   TestRepositoryRef_ValidateFields/missing_org_reponame
=== RUN   TestRepositoryRef_ValidateFields/missing_org_name
=== RUN   TestRepositoryRef_ValidateFields/missing_org_domain
=== RUN   TestRepositoryRef_ValidateFields/multiple_errors
--- PASS: TestRepositoryRef_ValidateFields (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/valid_user (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/valid_org (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/valid_sub-org (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_user_reponame (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_user_login (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_user_login#01 (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_user_domain (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_org_reponame (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_org_name (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/missing_org_domain (0.00s)
    --- PASS: TestRepositoryRef_ValidateFields/multiple_errors (0.00s)
=== RUN   TestGetDomainURL
=== RUN   TestGetDomainURL/github.com,_no_https
=== RUN   TestGetDomainURL/github.com,_with_https
=== RUN   TestGetDomainURL/github_enterprise,_no_https
=== RUN   TestGetDomainURL/github_enterprise,_with_http
=== RUN   TestGetDomainURL/github_enterprise,_with_https
=== RUN   TestGetDomainURL/gitlab.com,_no_https
=== RUN   TestGetDomainURL/gitlab.com,_with_https
=== RUN   TestGetDomainURL/self_hosted_gitlab,_no_https
=== RUN   TestGetDomainURL/self_hosted_gitlab,_with_https
=== RUN   TestGetDomainURL/self_hosted_gitlab,_with_http
--- PASS: TestGetDomainURL (0.00s)
    --- PASS: TestGetDomainURL/github.com,_no_https (0.00s)
    --- PASS: TestGetDomainURL/github.com,_with_https (0.00s)
    --- PASS: TestGetDomainURL/github_enterprise,_no_https (0.00s)
    --- PASS: TestGetDomainURL/github_enterprise,_with_http (0.00s)
    --- PASS: TestGetDomainURL/github_enterprise,_with_https (0.00s)
    --- PASS: TestGetDomainURL/gitlab.com,_no_https (0.00s)
    --- PASS: TestGetDomainURL/gitlab.com,_with_https (0.00s)
    --- PASS: TestGetDomainURL/self_hosted_gitlab,_no_https (0.00s)
    --- PASS: TestGetDomainURL/self_hosted_gitlab,_with_https (0.00s)
    --- PASS: TestGetDomainURL/self_hosted_gitlab,_with_http (0.00s)
=== RUN   TestDefaulting
=== RUN   TestDefaulting/DeployKey:_empty
=== RUN   TestDefaulting/DeployKey:_don't_set_if_non-nil_(default)
=== RUN   TestDefaulting/DeployKey:_don't_set_if_non-nil_(non-default)
=== RUN   TestDefaulting/Repository:_empty
=== RUN   TestDefaulting/Repository:_don't_set_if_non-nil_(default)
=== RUN   TestDefaulting/Repository:_don't_set_if_non-nil_(non-default)
=== RUN   TestDefaulting/TeamAccess:_empty
=== RUN   TestDefaulting/TeamAccess:_don't_set_if_non-nil_(default)
=== RUN   TestDefaulting/TeamAccess:_don't_set_if_non-nil_(non-default)
--- PASS: TestDefaulting (0.00s)
    --- PASS: TestDefaulting/DeployKey:_empty (0.00s)
    --- PASS: TestDefaulting/DeployKey:_don't_set_if_non-nil_(default) (0.00s)
    --- PASS: TestDefaulting/DeployKey:_don't_set_if_non-nil_(non-default) (0.00s)
    --- PASS: TestDefaulting/Repository:_empty (0.00s)
    --- PASS: TestDefaulting/Repository:_don't_set_if_non-nil_(default) (0.00s)
    --- PASS: TestDefaulting/Repository:_don't_set_if_non-nil_(non-default) (0.00s)
    --- PASS: TestDefaulting/TeamAccess:_empty (0.00s)
    --- PASS: TestDefaulting/TeamAccess:_don't_set_if_non-nil_(default) (0.00s)
    --- PASS: TestDefaulting/TeamAccess:_don't_set_if_non-nil_(non-default) (0.00s)
=== RUN   TestDeployKey_Validate
=== RUN   TestDeployKey_Validate/valid_create
=== RUN   TestDeployKey_Validate/valid_create,_with_all_checked_fields_populated
=== RUN   TestDeployKey_Validate/invalid_create,_missing_name
=== RUN   TestDeployKey_Validate/invalid_create,_missing_key
--- PASS: TestDeployKey_Validate (0.00s)
    --- PASS: TestDeployKey_Validate/valid_create (0.00s)
    --- PASS: TestDeployKey_Validate/valid_create,_with_all_checked_fields_populated (0.00s)
    --- PASS: TestDeployKey_Validate/invalid_create,_missing_name (0.00s)
    --- PASS: TestDeployKey_Validate/invalid_create,_missing_key (0.00s)
=== RUN   TestRepository_Validate
=== RUN   TestRepository_Validate/valid_create_and_update,_with_valid_enum_and_description
=== RUN   TestRepository_Validate/invalid_create_and_update,_invalid_enum
--- PASS: TestRepository_Validate (0.00s)
    --- PASS: TestRepository_Validate/valid_create_and_update,_with_valid_enum_and_description (0.00s)
    --- PASS: TestRepository_Validate/invalid_create_and_update,_invalid_enum (0.00s)
=== RUN   TestTeamAccess_Validate
=== RUN   TestTeamAccess_Validate/valid_create,_required_field_set
=== RUN   TestTeamAccess_Validate/invalid_create,_required_name
=== RUN   TestTeamAccess_Validate/valid_create,_also_including_valid_repoinfo
=== RUN   TestTeamAccess_Validate/valid_create,_with_valid_enum
=== RUN   TestTeamAccess_Validate/invalid_create,_invalid_enum
--- PASS: TestTeamAccess_Validate (0.00s)
    --- PASS: TestTeamAccess_Validate/valid_create,_required_field_set (0.00s)
    --- PASS: TestTeamAccess_Validate/invalid_create,_required_name (0.00s)
    --- PASS: TestTeamAccess_Validate/valid_create,_also_including_valid_repoinfo (0.00s)
    --- PASS: TestTeamAccess_Validate/valid_create,_with_valid_enum (0.00s)
    --- PASS: TestTeamAccess_Validate/invalid_create,_invalid_enum (0.00s)
PASS
coverage: 92.2% of statements
ok  	github.com/fluxcd/go-git-providers/gitprovider	0.055s	coverage: 92.2% of statements
?   	github.com/fluxcd/go-git-providers/gitprovider/cache	[no test files]
?   	github.com/fluxcd/go-git-providers/gitprovider/testutils	[no test files]
=== RUN   Test_NewClient
=== RUN   Test_NewClient/no_host
=== RUN   Test_NewClient/wrong_host
=== RUN   Test_NewClient/default_host
=== RUN   Test_NewClient/my_specific_host
--- PASS: Test_NewClient (0.00s)
    --- PASS: Test_NewClient/no_host (0.00s)
    --- PASS: Test_NewClient/wrong_host (0.00s)
    --- PASS: Test_NewClient/default_host (0.00s)
    --- PASS: Test_NewClient/my_specific_host (0.00s)
=== RUN   Test_Do
=== RUN   Test_Do/test_GET_method
=== RUN   Test_Do/test_POST_method
=== RUN   Test_Do/test_POST_with_wrong_headers_method
=== RUN   Test_Do/test_POST_without_body
--- PASS: Test_Do (0.01s)
    --- PASS: Test_Do/test_GET_method (0.00s)
    --- PASS: Test_Do/test_POST_method (0.00s)
    --- PASS: Test_Do/test_POST_with_wrong_headers_method (0.00s)
    --- PASS: Test_Do/test_POST_without_body (0.00s)
=== RUN   Test_DoWithRetry
=== RUN   Test_DoWithRetry/test_2_retries
=== RUN   Test_DoWithRetry/test_5_retries
--- PASS: Test_DoWithRetry (5.25s)
    --- PASS: Test_DoWithRetry/test_2_retries (0.00s)
    --- PASS: Test_DoWithRetry/test_5_retries (5.25s)
=== RUN   TestNewCommit
=== RUN   TestNewCommit/Create_Valid_Commit
=== RUN   TestNewCommit/CreateCommit_Invalid_Commit
--- PASS: TestNewCommit (0.74s)
    --- PASS: TestNewCommit/Create_Valid_Commit (0.00s)
    --- PASS: TestNewCommit/CreateCommit_Invalid_Commit (0.00s)
=== RUN   TestCreateCommit
--- PASS: TestCreateCommit (1.21s)
=== RUN   TestGetGroup
=== RUN   TestGetGroup/test_group_does_not_exist
=== RUN   TestGetGroup/test_a_group
--- PASS: TestGetGroup (0.00s)
    --- PASS: TestGetGroup/test_group_does_not_exist (0.00s)
    --- PASS: TestGetGroup/test_a_group (0.00s)
=== RUN   TestListGroup
--- PASS: TestListGroup (0.00s)
=== RUN   TestListGroupMembers
--- PASS: TestListGroupMembers (0.00s)
=== RUN   TestGetProject
=== RUN   TestGetProject/test_project_does_not_exist
=== RUN   TestGetProject/test_a_project
--- PASS: TestGetProject (0.00s)
    --- PASS: TestGetProject/test_project_does_not_exist (0.00s)
    --- PASS: TestGetProject/test_a_project (0.00s)
=== RUN   TestListProjects
--- PASS: TestListProjects (0.00s)
=== RUN   TestListProjectGroupsPermission
--- PASS: TestListProjectGroupsPermission (0.00s)
=== RUN   TestListProjectUsersPermission
--- PASS: TestListProjectUsersPermission (0.00s)
=== RUN   TestGetRepository
=== RUN   TestGetRepository/test_repository_does_not_exist
=== RUN   TestGetRepository/test_a_repository
--- PASS: TestGetRepository (0.00s)
    --- PASS: TestGetRepository/test_repository_does_not_exist (0.00s)
    --- PASS: TestGetRepository/test_a_repository (0.00s)
=== RUN   TestListRepositories
=== RUN   TestListRepositories/test_a_list_of_repositories
=== RUN   TestListRepositories/test_a_list_of_user_repositories
--- PASS: TestListRepositories (0.00s)
    --- PASS: TestListRepositories/test_a_list_of_repositories (0.00s)
    --- PASS: TestListRepositories/test_a_list_of_user_repositories (0.00s)
=== RUN   TestCreateRepository
=== RUN   TestCreateRepository/repository_1
=== RUN   TestCreateRepository/repository_2
=== RUN   TestCreateRepository/nil_repo
--- PASS: TestCreateRepository (0.00s)
    --- PASS: TestCreateRepository/repository_1 (0.00s)
    --- PASS: TestCreateRepository/repository_2 (0.00s)
    --- PASS: TestCreateRepository/nil_repo (0.00s)
=== RUN   TestUpdateRepository
=== RUN   TestUpdateRepository/update_project
=== RUN   TestUpdateRepository/update_name
--- PASS: TestUpdateRepository (0.00s)
    --- PASS: TestUpdateRepository/update_project (0.00s)
    --- PASS: TestUpdateRepository/update_name (0.00s)
=== RUN   TestDeleteRepository
=== RUN   TestDeleteRepository/test_repository_does_not_exist
=== RUN   TestDeleteRepository/test_a_repository
--- PASS: TestDeleteRepository (0.00s)
    --- PASS: TestDeleteRepository/test_repository_does_not_exist (0.00s)
    --- PASS: TestDeleteRepository/test_a_repository (0.00s)
=== RUN   TestGetRepositoryGroupPermission
=== RUN   TestGetRepositoryGroupPermission/test_Reader_permission
=== RUN   TestGetRepositoryGroupPermission/test_Writer_permission
=== RUN   TestGetRepositoryGroupPermission/test_Admin_permission
--- PASS: TestGetRepositoryGroupPermission (0.00s)
    --- PASS: TestGetRepositoryGroupPermission/test_Reader_permission (0.00s)
    --- PASS: TestGetRepositoryGroupPermission/test_Writer_permission (0.00s)
    --- PASS: TestGetRepositoryGroupPermission/test_Admin_permission (0.00s)
=== RUN   TestListRepositoryGroupsPermission
--- PASS: TestListRepositoryGroupsPermission (0.00s)
=== RUN   TestUpdateRepositoryGroupsPermission
=== RUN   TestUpdateRepositoryGroupsPermission/test_promote_to_Writer
=== RUN   TestUpdateRepositoryGroupsPermission/test_promote_to_Admin
=== RUN   TestUpdateRepositoryGroupsPermission/test_promote_to_BDFL
--- PASS: TestUpdateRepositoryGroupsPermission (0.00s)
    --- PASS: TestUpdateRepositoryGroupsPermission/test_promote_to_Writer (0.00s)
    --- PASS: TestUpdateRepositoryGroupsPermission/test_promote_to_Admin (0.00s)
    --- PASS: TestUpdateRepositoryGroupsPermission/test_promote_to_BDFL (0.00s)
=== RUN   TestListRepositoryUsersPermission
--- PASS: TestListRepositoryUsersPermission (0.00s)
=== RUN   TestGetUser
=== RUN   TestGetUser/test_user_does_not_exist
=== RUN   TestGetUser/test_a_user
--- PASS: TestGetUser (0.00s)
    --- PASS: TestGetUser/test_user_does_not_exist (0.00s)
    --- PASS: TestGetUser/test_a_user (0.00s)
=== RUN   TestUserList
--- PASS: TestUserList (0.00s)
PASS
coverage: 70.0% of statements
ok  	github.com/fluxcd/go-git-providers/stash	7.287s	coverage: 70.0% of statements
=== RUN   TestMultiError_As
=== RUN   TestMultiError_As/cast_to_MultiError,_containing_data,_success
=== RUN   TestMultiError_As/cast_to_custom_type_embedded_in_error_list,_success
=== RUN   TestMultiError_As/cast_to_custom_type_not_in_error_list,_fail
--- PASS: TestMultiError_As (0.00s)
    --- PASS: TestMultiError_As/cast_to_MultiError,_containing_data,_success (0.00s)
    --- PASS: TestMultiError_As/cast_to_custom_type_embedded_in_error_list,_success (0.00s)
    --- PASS: TestMultiError_As/cast_to_custom_type_not_in_error_list,_fail (0.00s)
=== RUN   TestMultiError_Is
=== RUN   TestMultiError_Is/has_wrapped_required_error
=== RUN   TestMultiError_Is/doesn't_have_error
=== RUN   TestMultiError_Is/is_multierror
--- PASS: TestMultiError_Is (0.00s)
    --- PASS: TestMultiError_Is/has_wrapped_required_error (0.00s)
    --- PASS: TestMultiError_Is/doesn't_have_error (0.00s)
    --- PASS: TestMultiError_Is/is_multierror (0.00s)
=== RUN   Test_ExpectErrors
=== RUN   Test_ExpectErrors/normal_wrapping
=== RUN   Test_ExpectErrors/multierror_wrapping
=== RUN   Test_ExpectErrors/one_error_not_wrapped
=== RUN   Test_ExpectErrors/two_different_fmt.Errors_should_not_be_equal
=== RUN   Test_ExpectErrors/two_different_fmt.Errors_should_not_be_equal#01
=== RUN   Test_ExpectErrors/two_different_errorStrings_should_not_match
=== RUN   Test_ExpectErrors/two_errors_not_found_in_multierror
=== RUN   Test_ExpectErrors/expected_no_error,_got_one
=== RUN   Test_ExpectErrors/expected_no_error,_got_none
=== RUN   Test_ExpectErrors/struct_types
=== RUN   Test_ExpectErrors/multierror_struct_propagation
--- PASS: Test_ExpectErrors (0.00s)
    --- PASS: Test_ExpectErrors/normal_wrapping (0.00s)
    --- PASS: Test_ExpectErrors/multierror_wrapping (0.00s)
    --- PASS: Test_ExpectErrors/one_error_not_wrapped (0.00s)
    --- PASS: Test_ExpectErrors/two_different_fmt.Errors_should_not_be_equal (0.00s)
    --- PASS: Test_ExpectErrors/two_different_fmt.Errors_should_not_be_equal#01 (0.00s)
    --- PASS: Test_ExpectErrors/two_different_errorStrings_should_not_match (0.00s)
    --- PASS: Test_ExpectErrors/two_errors_not_found_in_multierror (0.00s)
    --- PASS: Test_ExpectErrors/expected_no_error,_got_one (0.00s)
    --- PASS: Test_ExpectErrors/expected_no_error,_got_none (0.00s)
    --- PASS: Test_ExpectErrors/struct_types (0.00s)
    --- PASS: Test_ExpectErrors/multierror_struct_propagation (0.00s)
=== RUN   Test_validator_Error
=== RUN   Test_validator_Error/nil_errors
=== RUN   Test_validator_Error/zero_errors
=== RUN   Test_validator_Error/many_nil_errors
=== RUN   Test_validator_Error/append_nil_error
=== RUN   Test_validator_Error/one_required,_one_existing_nil_error_ignored
=== RUN   Test_validator_Error/one_invalid,_many_field_paths
=== RUN   Test_validator_Error/one_invalid,_using_a_custom_error
=== RUN   Test_validator_Error/return_multiple_errors
--- PASS: Test_validator_Error (0.00s)
    --- PASS: Test_validator_Error/nil_errors (0.00s)
    --- PASS: Test_validator_Error/zero_errors (0.00s)
    --- PASS: Test_validator_Error/many_nil_errors (0.00s)
    --- PASS: Test_validator_Error/append_nil_error (0.00s)
    --- PASS: Test_validator_Error/one_required,_one_existing_nil_error_ignored (0.00s)
    --- PASS: Test_validator_Error/one_invalid,_many_field_paths (0.00s)
    --- PASS: Test_validator_Error/one_invalid,_using_a_custom_error (0.00s)
    --- PASS: Test_validator_Error/return_multiple_errors (0.00s)
=== RUN   TestValidateTargets
=== RUN   TestValidateTargets/multiple_passing
=== RUN   TestValidateTargets/two_failing_for_one_specific
=== RUN   TestValidateTargets/two_failing,_one_for_each
--- PASS: TestValidateTargets (0.00s)
    --- PASS: TestValidateTargets/multiple_passing (0.00s)
    --- PASS: TestValidateTargets/two_failing_for_one_specific (0.00s)
    --- PASS: TestValidateTargets/two_failing,_one_for_each (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/fluxcd/go-git-providers/validation	0.044s	coverage: 100.0% of statements
 ```
