### PR TITLE
Go stash deploy keys service

### DIFF
--- a/stash/branch.go
+++ b/stash/branch.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	branchesURI      = "branches"
+	defaultBranchURI = "default"
+)
+
+// Branches interface defines the methods that can be used to
+// retrieve branches of a repository.
+type Branches interface {
+	List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*BranchList, error)
+	Get(ctx context.Context, projectKey, repositorySlug, branchID string) (*Branch, error)
+	Default(ctx context.Context, projectKey, repositorySlug string) (*Branch, error)
+}
+
+// BranchesService is a client for communicating with stash branches endpoint
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+type BranchesService service
+
+// Branch represents a branch of a repository.
+type Branch struct {
+	// Session is the session object for the branch.
+	Session `json:"sessionInfo,omitempty"`
+	// DisplayID is the branch name e.g. main.
+	DisplayID string `json:"displayId,omitempty"`
+	// ID is the branch reference e.g. refs/heads/main.
+	ID string `json:"id,omitempty"`
+	// IsDefault is true if this is the default branch.
+	IsDefault bool `json:"isDefault,omitempty"`
+	// LatestChangeset is the latest changeset on this branch.
+	LatestChangeset string `json:"latestChangeset,omitempty"`
+	// LatestCommit is the latest commit on this branch.
+	LatestCommit string `json:"latestCommit,omitempty"`
+	// Type is the type of branch.
+	Type string `json:"type,omitempty"`
+}
+
+// BranchList is a list of branches.
+type BranchList struct {
+	// Paging is the paging information.
+	Paging
+	// Branches is the list of branches.
+	Branches []*Branch `json:"values,omitempty"`
+}
+
+// GetBranches returns the list of branches.
+func (b *BranchList) GetBranches() []*Branch {
+	return b.Branches
+}
+
+// List returns the list of branches.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a BranchList struct is returned to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/branches".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *BranchesService) List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*BranchList, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, branchesURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("list branches request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list branches failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	b := &BranchList{}
+
+	if err := json.Unmarshal(res, b); err != nil {
+		return nil, fmt.Errorf("list branches for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	for _, branches := range b.GetBranches() {
+		branches.Session.set(resp)
+	}
+
+	return b, nil
+}
+
+// Get retrieves a stash branch given it's ID i.e a git reference.
+// Get uses the endpoint
+// "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/branches?base&details&filterText&orderBy".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *BranchesService) Get(ctx context.Context, projectKey, repositorySlug, branchID string) (*Branch, error) {
+	query := url.Values{
+		"filterText": []string{branchID},
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, branchesURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("get branch request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get branch failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	b := &Branch{}
+	if err := json.Unmarshal(res, b); err != nil {
+		return nil, fmt.Errorf("get branch for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	b.Session.set(resp)
+	return b, nil
+
+}
+
+// Default retrieves the default branch of a repository.
+// Default uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/branches/default".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *BranchesService) Default(ctx context.Context, projectKey, repositorySlug string) (*Branch, error) {
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, branchesURI, defaultBranchURI))
+	if err != nil {
+		return nil, fmt.Errorf("get branch request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get branch failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	b := &Branch{}
+	if err := json.Unmarshal(res, b); err != nil {
+		return nil, fmt.Errorf("list branches for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	b.Session.set(resp)
+
+	return b, nil
+}

--- a/stash/branch_test.go
+++ b/stash/branch_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetBranch(t *testing.T) {
+	tests := []struct {
+		name     string
+		branchID string
+	}{
+		{
+			name:     "test branch does not exist",
+			branchID: "features",
+		},
+		{
+			name:     "test main branch",
+			branchID: "refs/heads/main",
+		},
+	}
+
+	validBranchID := []string{"refs/heads/main"}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s", stashURIprefix, projectsURI, RepositoriesURI, branchesURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		for _, substr := range validBranchID {
+			if r.URL.Query().Get("filterText") == substr {
+				w.WriteHeader(http.StatusOK)
+				u := &Branch{
+					ID:        "refs/heads/main",
+					DisplayID: "main",
+				}
+				json.NewEncoder(w).Encode(u)
+				return
+			}
+		}
+
+		http.Error(w, "The specified branch does not exist", http.StatusNotFound)
+
+		return
+
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			b, err := client.Branches.Get(ctx, "prj1", "repo1", tt.branchID)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Fatalf("Branches.Get returned error: %v", err)
+				}
+				return
+			}
+
+			if b.ID != tt.branchID {
+				t.Errorf("Branches.Get returned branch:\n%s, want:\n%s", b.ID, tt.branchID)
+			}
+
+		})
+	}
+}
+
+func TestListBranches(t *testing.T) {
+	bIDs := []*Branch{
+		{ID: "refs/heads/main"}, {ID: "refs/heads/release"}, {ID: "refs/heads/feature"}, {ID: "refs/heads/hotfix"}}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s", stashURIprefix, projectsURI, RepositoriesURI, branchesURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		b := struct {
+			Branches []*Branch `json:"values"`
+		}{[]*Branch{
+			bIDs[0],
+			bIDs[1],
+			bIDs[2],
+			bIDs[3],
+		}}
+		json.NewEncoder(w).Encode(b)
+		return
+
+	})
+	ctx := context.Background()
+	list, err := client.Branches.List(ctx, "prj1", "repo1", nil)
+	if err != nil {
+		t.Fatalf("Branches.List returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(bIDs, list.Branches); diff != "" {
+		t.Errorf("Branches.List returned diff (want -> got):\n%s", diff)
+	}
+
+}
+
+func TestDefaultBranch(t *testing.T) {
+	d := struct {
+		ID        string `json:"id"`
+		DisplayID string `json:"displayId"`
+	}{
+		"refs/heads/main",
+		"main",
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s/%s", stashURIprefix, projectsURI, RepositoriesURI, branchesURI, defaultBranchURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		u := &Branch{
+			ID:        d.ID,
+			DisplayID: d.DisplayID,
+		}
+		json.NewEncoder(w).Encode(u)
+
+		return
+	})
+
+	ctx := context.Background()
+	b, err := client.Branches.Default(ctx, "prj1", "repo1")
+	if err != nil {
+		if err != ErrNotFound {
+			t.Fatalf("Branches.Default returned error: %v", err)
+		}
+		return
+	}
+
+	if b.ID != d.ID {
+		t.Errorf("Branches.Default returned branch:\n%s, want:\n %s", b.ID, d.ID)
+	}
+}

--- a/stash/client.go
+++ b/stash/client.go
@@ -109,6 +109,7 @@ type Client struct {
 	Repositories Repositories
 	Branches     Branches
 	Commits      Commits
+	PullRequests PullRequests
 }
 
 // RateLimiter is the interface that wraps the basic Wait method.
@@ -206,6 +207,7 @@ func NewClient(httpClient *http.Client, host string, header *http.Header, logger
 	c.Repositories = &RepositoriesService{Client: c}
 	c.Branches = &BranchesService{Client: c}
 	c.Commits = &CommitsService{Client: c}
+	c.PullRequests = &PullRequestsService{Client: c}
 
 	return c, nil
 }

--- a/stash/client.go
+++ b/stash/client.go
@@ -110,6 +110,7 @@ type Client struct {
 	Branches     Branches
 	Commits      Commits
 	PullRequests PullRequests
+	DeployKeys   DeployKeys
 }
 
 // RateLimiter is the interface that wraps the basic Wait method.
@@ -208,6 +209,7 @@ func NewClient(httpClient *http.Client, host string, header *http.Header, logger
 	c.Branches = &BranchesService{Client: c}
 	c.Commits = &CommitsService{Client: c}
 	c.PullRequests = &PullRequestsService{Client: c}
+	c.DeployKeys = &DeployKeysService{Client: c}
 
 	return c, nil
 }

--- a/stash/client.go
+++ b/stash/client.go
@@ -107,6 +107,7 @@ type Client struct {
 	Projects     Projects
 	Git          Git
 	Repositories Repositories
+	Branches     Branches
 }
 
 // RateLimiter is the interface that wraps the basic Wait method.
@@ -202,6 +203,7 @@ func NewClient(httpClient *http.Client, host string, header *http.Header, logger
 	c.Projects = &ProjectsService{Client: c}
 	c.Git = &GitService{Client: c}
 	c.Repositories = &RepositoriesService{Client: c}
+	c.Branches = &BranchesService{Client: c}
 
 	return c, nil
 }
@@ -335,42 +337,42 @@ func (c *Client) configureLimiter() error {
 	return nil
 }
 
-// RequestOptions defines the optional parameters for the request.
-type RequestOptions struct {
-	// Body is the request body.
-	Body io.Reader
-	// Header is the request header.
-	Header http.Header
-	// Query is the request query.
-	Query url.Values
+// requestOptions defines the optional parameters for the request.
+type requestOptions struct {
+	// body is the request body.
+	body io.Reader
+	// header is the request header.
+	header http.Header
+	// query is the request query.
+	query url.Values
 }
 
 // RequestOptionFunc is a function that set request options.
-type RequestOptionFunc func(*RequestOptions)
+type RequestOptionFunc func(*requestOptions)
 
 // WithQuery adds the query parameters to the request.
 func WithQuery(query url.Values) RequestOptionFunc {
-	return func(r *RequestOptions) {
+	return func(r *requestOptions) {
 		if query != nil {
-			r.Query = query
+			r.query = query
 		}
 	}
 }
 
 // WithBody adds the body to the request.
 func WithBody(body io.Reader) RequestOptionFunc {
-	return func(r *RequestOptions) {
+	return func(r *requestOptions) {
 		if body != nil {
-			r.Body = body
+			r.body = body
 		}
 	}
 }
 
 // WithHeader adds the headers to the request.
 func WithHeader(header http.Header) RequestOptionFunc {
-	return func(r *RequestOptions) {
+	return func(r *requestOptions) {
 		if header != nil {
-			r.Header = header
+			r.header = header
 		}
 	}
 }
@@ -395,18 +397,18 @@ func (c *Client) NewRequest(ctx context.Context, method string, path string, opt
 		method = http.MethodGet
 	}
 
-	r := RequestOptions{}
+	r := requestOptions{}
 	for _, opt := range opts {
 		opt(&r)
 	}
 
-	if r.Query == nil {
-		r.Query = url.Values{}
+	if r.query == nil {
+		r.query = url.Values{}
 	}
 
-	u.RawQuery = r.Query.Encode()
+	u.RawQuery = r.query.Encode()
 
-	req, err := http.NewRequest(method, u.String(), r.Body)
+	req, err := http.NewRequest(method, u.String(), r.body)
 	if err != nil {
 		return req, fmt.Errorf("failed create request for %s %s, %w", method, u.String(), err)
 	}
@@ -421,8 +423,8 @@ func (c *Client) NewRequest(ctx context.Context, method string, path string, opt
 		}
 	}
 
-	if r.Header != nil {
-		for k, v := range r.Header {
+	if r.header != nil {
+		for k, v := range r.header {
 			for _, s := range v {
 				req.Header.Add(k, s)
 			}

--- a/stash/client.go
+++ b/stash/client.go
@@ -108,6 +108,7 @@ type Client struct {
 	Git          Git
 	Repositories Repositories
 	Branches     Branches
+	Commits      Commits
 }
 
 // RateLimiter is the interface that wraps the basic Wait method.
@@ -204,6 +205,7 @@ func NewClient(httpClient *http.Client, host string, header *http.Header, logger
 	c.Git = &GitService{Client: c}
 	c.Repositories = &RepositoriesService{Client: c}
 	c.Branches = &BranchesService{Client: c}
+	c.Commits = &CommitsService{Client: c}
 
 	return c, nil
 }

--- a/stash/commits.go
+++ b/stash/commits.go
@@ -102,6 +102,10 @@ func (s *CommitsService) List(ctx context.Context, projectKey, repositorySlug st
 		return nil, ErrNotFound
 	}
 
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("list commits failed: %s", resp.Status)
+	}
+
 	c := &CommitList{}
 	if err := json.Unmarshal(res, c); err != nil {
 		return nil, fmt.Errorf("list commits for repository failed, unable to unmarshall repository json: %w", err)
@@ -128,6 +132,10 @@ func (s *CommitsService) Get(ctx context.Context, projectKey, repositorySlug, co
 
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("get commits failed: %s", resp.Status)
 	}
 
 	c := &CommitObject{}

--- a/stash/commits.go
+++ b/stash/commits.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	commitsURI = "commits"
+)
+
+// Commits interface defines the methods that can be used to
+// retrieve commits of a repository.
+type Commits interface {
+	List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*CommitList, error)
+	Get(ctx context.Context, projectKey, repositorySlug, commitID string) (*CommitObject, error)
+}
+
+// CommitsService is a client for communicating with stash commits endpoint
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+type CommitsService service
+
+// CommitObject represents a commit in stash
+type CommitObject struct {
+	// Session is the session object for the branch.
+	Session `json:"sessionInfo,omitempty"`
+	// Author is the author of the commit.
+	Author User `json:"author,omitempty"`
+	// AuthorTimestamp is the timestamp of the author of the commit.
+	AuthorTimestamp int64 `json:"authorTimestamp,omitempty"`
+	// Committer is the committer of the commit.
+	Committer User `json:"committer,omitempty"`
+	// CommitterTimestamp is the timestamp of the committer of the commit.
+	CommitterTimestamp int64 `json:"committerTimestamp,omitempty"`
+	// DisplayID is the display ID of the commit.
+	DisplayID string `json:"displayId,omitempty"`
+	// ID is the ID of the commit i.e the SHA1.
+	ID string `json:"id,omitempty"`
+	// Message is the message of the commit.
+	Message string `json:"message,omitempty"`
+	// Parents is the list of parents of the commit.
+	Parents []*Parent `json:"parents,omitempty"`
+}
+
+// Parent represents a parent of a commit.
+type Parent struct {
+	// DisplayID is the display ID of the commit.
+	DisplayID string `json:"displayId,omitempty"`
+	// ID is the ID of the commit i.e the SHA1.
+	ID string `json:"id,omitempty"`
+}
+
+// CommitList represents a list of commits in stash
+type CommitList struct {
+	// Paging is the paging information.
+	Paging
+	// Commits is the list of commits.
+	Commits []*CommitObject `json:"values,omitempty"`
+}
+
+// GetCommits returns the list of commits
+func (c *CommitList) GetCommits() []*CommitObject {
+	return c.Commits
+}
+
+// List returns the list of commits.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a CommitList struct is returned to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/commits".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *CommitsService) List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*CommitList, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, commitsURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("list commits request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list commits failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	c := &CommitList{}
+	if err := json.Unmarshal(res, c); err != nil {
+		return nil, fmt.Errorf("list commits for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	for _, commit := range c.GetCommits() {
+		commit.Session.set(resp)
+	}
+	return c, nil
+}
+
+// Get retrieves a stash commit given it's ID i.e a SHA1.
+// Get uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/commits/{commitID}".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *CommitsService) Get(ctx context.Context, projectKey, repositorySlug, commitID string) (*CommitObject, error) {
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, commitsURI, commitID))
+	if err != nil {
+		return nil, fmt.Errorf("get commit request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get commit failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	c := &CommitObject{}
+	if err := json.Unmarshal(res, c); err != nil {
+		return nil, fmt.Errorf("get commit failed, unable to unmarshall json: %w", err)
+	}
+
+	c.Session.set(resp)
+
+	return c, nil
+}

--- a/stash/commits_test.go
+++ b/stash/commits_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetCommit(t *testing.T) {
+	tests := []struct {
+		name     string
+		commitID string
+	}{
+		{
+			name:     "test a commit",
+			commitID: "abcdef0123abcdef4567abcdef8987abcdef6543",
+		},
+		{
+			name:     "test commit does not exist",
+			commitID: "*°0#13jbkjfbvsqbùbjùrdfbgzeo'àtu)éuçt&-y",
+		},
+	}
+
+	validCommitID := []string{"abcdef0123abcdef4567abcdef8987abcdef6543"}
+
+	mux, client := setup(t)
+
+	fmt.Println("commit")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s/%s", stashURIprefix, projectsURI, RepositoriesURI, commitsURI, tt.commitID)
+			mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+				for _, substr := range validCommitID {
+					if path.Base(r.URL.String()) == substr {
+						w.WriteHeader(http.StatusOK)
+						c := &CommitObject{
+							ID:        substr,
+							DisplayID: substr[:10],
+						}
+
+						json.NewEncoder(w).Encode(c)
+						return
+					}
+				}
+
+				http.Error(w, "The specified commit does not exist", http.StatusNotFound)
+
+				return
+
+			})
+
+			ctx := context.Background()
+			c, err := client.Commits.Get(ctx, "prj1", "repo1", tt.commitID)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Fatalf("Commits.Get returned error: %v", err)
+				}
+				return
+			}
+
+			if c.ID != tt.commitID {
+				t.Fatalf("Commits.Get returned commit %s, want %s", c.ID, tt.commitID)
+			}
+
+		})
+	}
+}
+
+func TestListCommits(t *testing.T) {
+	cIDs := []*CommitObject{
+		{ID: "abcdef0123abcdef4567abcdef8987abcdef6543"},
+		{ID: "aerfdef09893abcdef4567abcdef898abcdef652"},
+		{ID: "abcdef3456abcdef4567abcdef8987abcdef6657"},
+		{ID: "abcdef9876abcdef4567abcdef8987abcdef4357"}}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s", stashURIprefix, projectsURI, RepositoriesURI, commitsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		b := struct {
+			Commits []*CommitObject `json:"values"`
+		}{[]*CommitObject{
+			cIDs[0],
+			cIDs[1],
+			cIDs[2],
+			cIDs[3],
+		}}
+		json.NewEncoder(w).Encode(b)
+		return
+
+	})
+	ctx := context.Background()
+	list, err := client.Commits.List(ctx, "prj1", "repo1", nil)
+	if err != nil {
+		t.Fatalf("Commits.List returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(cIDs, list.Commits); diff != "" {
+		t.Errorf("Commits.List returned diff (want -> got):\n%s", diff)
+	}
+
+}

--- a/stash/commits_test.go
+++ b/stash/commits_test.go
@@ -46,8 +46,6 @@ func TestGetCommit(t *testing.T) {
 
 	mux, client := setup(t)
 
-	fmt.Println("commit")
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s/%s", stashURIprefix, projectsURI, RepositoriesURI, commitsURI, tt.commitID)

--- a/stash/deploy_keys.go
+++ b/stash/deploy_keys.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	deployKeysURI    = "ssh"
+	stashURIkeys     = "/rest/keys/1.0"
+	keyPermisionsURI = "permission"
+)
+
+var (
+	// ErrBadRequest is returned when a request is malformed.
+	ErrBadRequest = fmt.Errorf("Bad request")
+)
+
+// DeployKeys interface defines the methods for working with
+// repository access keys
+type DeployKeys interface {
+	List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*DeployKeyList, error)
+	Get(ctx context.Context, projectKey, repositorySlug string, keyID int) (*DeployKey, error)
+	Create(ctx context.Context, deployKey *DeployKey) (*DeployKey, error)
+	Delete(ctx context.Context, projectKey, repositorySlug string, keyID int) error
+	UpdateKeyPermission(ctx context.Context, projectKey, repositorySlug string, keyID int, permission string) (*DeployKey, error)
+}
+
+// DeployKeysService is a client for communicating with stash ssh keys endpoint
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-ssh-rest.html
+type DeployKeysService service
+
+// Key is a ssh key
+type Key struct {
+	// ID is the key id
+	ID int `json:"id,omitempty"`
+	// Label is the key label
+	Label string `json:"label,omitempty"`
+	// Text is the key text
+	// For example "text": "ssh-rsa AAAAB3... me@127.0.0.1"
+	Text string `json:"text,omitempty"`
+}
+
+// DeployKey is an access key for a repository
+type DeployKey struct {
+	// Session is the session object
+	Session `json:"sessionInfo,omitempty"`
+	// Key is the key object
+	Key `json:"key,omitempty"`
+	// Permissions is the key permission
+	// Available repository permissions are:
+	// REPO_READ
+	// REPO_WRITE
+	// REPO_ADMIN
+	Permission string `json:"permission,omitempty"`
+	// Repository is the repository object
+	Repository `json:"repository,omitempty"`
+}
+
+// DeployKeyList is a list of access keys
+type DeployKeyList struct {
+	Paging
+	DeployKeys []*DeployKey `json:"values,omitempty"`
+}
+
+// GetDeployKeys returns the list of deploy keys
+func (d *DeployKeyList) GetDeployKeys() []*DeployKey {
+	return d.DeployKeys
+}
+
+// List returns the list of access keys for the repository.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a DeployKeyList struct is returned to retrieve the next page of results.
+// List uses the endpoint "GET /rest/keys/1.0/projects/{projectKey}/repos/{repositorySlug}/ssh".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-ssh-rest.html
+func (s *DeployKeysService) List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*DeployKeyList, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newKeysURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, deployKeysURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("list deploy keys for repository request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list deploy keys for repository requests failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	keys := &DeployKeyList{}
+	if err := json.Unmarshal(res, keys); err != nil {
+		return nil, fmt.Errorf("list deploy keys for repository failed, unable to unmarshall json: %w", err)
+	}
+
+	for _, k := range keys.GetDeployKeys() {
+		k.Session.set(resp)
+	}
+
+	return keys, nil
+}
+
+// Get retrieves an access key given it's ID.
+// Get uses the endpoint "GET /rest/keys/1.0/projects/{projectKey}/repos/{repositorySlug}/ssh/{keyId}".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-ssh-rest.html
+func (s *DeployKeysService) Get(ctx context.Context, projectKey, repositorySlug string, keyID int) (*DeployKey, error) {
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newKeysURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, deployKeysURI, strconv.Itoa(keyID)))
+	if err != nil {
+		return nil, fmt.Errorf("get deploy key for repository  request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get deploy key for repository requests failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	key := &DeployKey{}
+	if err := json.Unmarshal(res, key); err != nil {
+		return nil, fmt.Errorf("get deploy key for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	key.Session.set(resp)
+
+	return key, nil
+}
+
+// Create creates an access key.
+// Create uses the endpoint "POST /rest/keys/1.0/projects/{projectKey}/repos/{repositorySlug}/ssh".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-ssh-rest.html
+func (s *DeployKeysService) Create(ctx context.Context, deployKey *DeployKey) (*DeployKey, error) {
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	body, err := marshallBody(deployKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall deploykey: %v", err)
+	}
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, newKeysURI(projectsURI, deployKey.Repository.Project.Key, RepositoriesURI, deployKey.Repository.Slug, deployKeysURI), WithBody(body), WithHeader(header))
+	if err != nil {
+		return nil, fmt.Errorf("create deploy key for repository  request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("create deploy key for repository requests failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("create deploy key for repository failed: %s", resp.Status)
+	}
+
+	key := &DeployKey{}
+	if err := json.Unmarshal(res, key); err != nil {
+		return nil, fmt.Errorf("create deploy key for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	key.Session.set(resp)
+
+	return key, nil
+}
+
+// Delete deletes the access key with the given ID
+// Delete uses the endpoint "Delete /rest/keys/1.0/projects/{projectKey}/repos/{repositorySlug}/ssh/{keyId}".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-ssh-rest.html
+func (s *DeployKeysService) Delete(ctx context.Context, projectKey, repositorySlug string, keyID int) error {
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, newKeysURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, deployKeysURI, strconv.Itoa(keyID)))
+	if err != nil {
+		return fmt.Errorf("delete deploy key for repository  request creation failed: %w", err)
+	}
+	_, _, err = s.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete deploy key for repository requests failed: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateKeyPermission updates the given access key permission
+// UpdateKeyPermission uses the endpoint "PUT /rest/keys/1.0/projects/{projectKey}/ssh/{keyId}/permission/{permission}".
+//
+func (s *DeployKeysService) UpdateKeyPermission(ctx context.Context, projectKey, repositorySlug string, keyID int, permission string) (*DeployKey, error) {
+	req, err := s.Client.NewRequest(ctx, http.MethodPut, newKeysURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, deployKeysURI, strconv.Itoa(keyID),
+		keyPermisionsURI, permission))
+	if err != nil {
+		return nil, fmt.Errorf("update deploy key permission for repository request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("update deploy key permission for repository requests failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	key := &DeployKey{}
+	if err := json.Unmarshal(res, key); err != nil {
+		return nil, fmt.Errorf("update deploy key for repository failed, unable to unmarshall repository json: %w", err)
+	}
+
+	key.Session.set(resp)
+
+	return key, nil
+}
+
+// newKeysURI builds stash keys URI
+func newKeysURI(elements ...string) string {
+	return strings.Join(append([]string{stashURIkeys}, elements...), "/")
+}

--- a/stash/deploy_keys_test.go
+++ b/stash/deploy_keys_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		keyID int
+	}{
+		{
+			name:  "test an access key",
+			keyID: 1,
+		},
+		{
+			name:  "test access key does not exist",
+			keyID: -1,
+		},
+	}
+
+	validKeyIDs := []string{"1"}
+
+	mux, client := setup(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s/%s", stashURIkeys, projectsURI, RepositoriesURI, deployKeysURI, strconv.Itoa(tt.keyID))
+			mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+				for _, substr := range validKeyIDs {
+					if path.Base(r.URL.String()) == substr {
+						w.WriteHeader(http.StatusOK)
+						k := &DeployKey{
+							Key: Key{
+								ID:    tt.keyID,
+								Text:  "ssh-rsa AAAAB3... me@127.0.0.1",
+								Label: "me@127.0.0.1",
+							},
+							Permission: "REPO_READ",
+							Repository: Repository{
+								Slug: "repo1",
+								Name: "repository 1",
+								Project: Project{
+									Key:  "prj1",
+									Name: "prjoject 1",
+								},
+							},
+						}
+
+						json.NewEncoder(w).Encode(k)
+						return
+					}
+				}
+
+				http.Error(w, "The specified access key does not exist", http.StatusNotFound)
+
+				return
+
+			})
+
+			ctx := context.Background()
+			k, err := client.DeployKeys.Get(ctx, "prj1", "repo1", tt.keyID)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Fatalf("DeployKeys.Get returned error: %v", err)
+				}
+				return
+			}
+
+			if k.Key.ID != tt.keyID {
+				t.Fatalf("DeployKeys.Get returned:\n%d, want:\n%d", k.Key.ID, tt.keyID)
+			}
+
+		})
+	}
+}
+
+func TestListKeys(t *testing.T) {
+	keyIDs := []*DeployKey{
+		{Key: Key{ID: 1}},
+		{Key: Key{ID: 2}},
+		{Key: Key{ID: 2}},
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s", stashURIkeys, projectsURI, RepositoriesURI, deployKeysURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		k := struct {
+			Values []*DeployKey `json:"values"`
+		}{[]*DeployKey{
+			keyIDs[0],
+			keyIDs[1],
+			keyIDs[2],
+		},
+		}
+		json.NewEncoder(w).Encode(k)
+		return
+
+	})
+	ctx := context.Background()
+	list, err := client.DeployKeys.List(ctx, "prj1", "repo1", nil)
+	if err != nil {
+		t.Fatalf("DeployKeys..List returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(keyIDs, list.DeployKeys); diff != "" {
+		t.Errorf("DeployKeys..List returned diff (want -> got):\n%s", diff)
+	}
+}
+
+func TestCreateKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  DeployKey
+	}{
+		{
+			name: "invalid key",
+			key: DeployKey{
+				Key: Key{
+					Text: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABABABAQCBejb9KVtNtpxsBf3rWd6hbJD2VRTzR5g8/84mQafhRk1NoDa3cCYujl1PZXWnh+mCJwa6sf2VLD6oWc4ce9cjbWORxj3w/WUmcjykz8JlmqY0nLCV6oy8m7OeM4NYd/+Zwbz5DmwlXADGsDbJH9ndiCADOqsGXkkG9Mid+1oYYp2IsL/60ShHa1/pLcHjwVndL9Kf7gBMu5ezH0liXvUqX0C0MKevVvgYTG6bEpPLsN15EIGQKU38ogUuOsbcv6xoIHI1J3rL1nzQtMef0VeI4Jl4jQzT7sQuTzjjlLAUjmLRx2ub2cuaweWK30Ahvm5CRbmD8X0KTDK6FVm9oZH/",
+				},
+				Permission: "",
+				Repository: Repository{
+					Slug: "my-repo",
+					Project: Project{
+						Key: "prj",
+					},
+				},
+			},
+		},
+		{
+			name: "writer key",
+			key: DeployKey{
+				Key: Key{
+					Text: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCBejb9KVtNtpxsBf3rWd6hbJD2VRTzR5g8/84mQafhRk1NoDa3cCYujl1PZXWnh+mCJwa6sf2VLD6oWc4ce9cjbWORxj3w/WUmcjykz8JlmqY0nLCV6oy8m7OeM4NYd/+Zwbz5DmwlXADGsDbJH9ndiCADOqsGXkkG9Mid+1oYYp2IsL/60ShHa1/pLcHjwVndL9Kf7gBMu5ezH0liXvUqX0C0MKevVvgYTG6bEpPLsN15EIGQKU38ogUuOsbcv6xoIHI1J3rL1nzQtMef0VeI4Jl4jQzT7sQuTzjjlLAUjmLRx2ub2cuaweWK30Ahvm5CRbmD8X0KTDK6FVm9oZH/",
+				},
+				Permission: "REPO_WRITE",
+				Repository: Repository{
+					Slug: "my-repo",
+					Project: Project{
+						Key: "prj",
+					},
+				},
+			},
+		},
+		{
+			name: "reader key",
+			key: DeployKey{
+				Key: Key{
+					Text: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABABABAQCBejb9KVtNtpxsBf3rWd6hbJD2VRTzR5g8/84mQafhRk1NoDa3cCYujl1PZXWnh+mCJwa6sf2VLD6oWc4ce9cjbWORxj3w/WUmcjykz8JlmqY0nLCV6oy8m7OeM4NYd/+Zwbz5DmwlXADGsDbJH9ndiCADOqsGXkkG9Mid+1oYYp2IsL/60ShHa1/pLcHjwVndL9Kf7gBMu5ezH0liXvUqX0C0MKevVvgYTG6bEpPLsN15EIGQKU38ogUuOsbcv6xoIHI1J3rL1nzQtMef0VeI4Jl4jQzT7sQuTzjjlLAUjmLRx2ub2cuaweWK30Ahvm5CRbmD8X0KTDK6FVm9oZH/",
+				},
+				Permission: "REPO_READ",
+				Repository: Repository{
+					Slug: "my-repo",
+					Project: Project{
+						Key: "prj",
+					},
+				},
+			},
+		},
+	}
+
+	permissions := []string{"REPO_READ", "REPO_WRITE", "REPO_ADMIN"}
+	IDCounter := 0
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj/%s/my-repo/%s", stashURIkeys, projectsURI, RepositoriesURI, deployKeysURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			req := &DeployKey{}
+			json.NewDecoder(r.Body).Decode(req)
+			for _, p := range permissions {
+				if req.Permission == p {
+					k := &DeployKey{
+						Key: Key{
+							ID:   IDCounter + 1,
+							Text: req.Key.Text,
+						},
+						Permission: p,
+						Repository: Repository{
+							Slug: "my-repo",
+							Project: Project{
+								Key: "prj",
+							},
+						},
+					}
+					json.NewEncoder(w).Encode(k)
+					return
+				}
+			}
+		}
+
+		http.Error(w, "The access key was not created due to wrong permission.", http.StatusBadRequest)
+
+		return
+
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k, err := client.DeployKeys.Create(ctx, &tt.key)
+			if err != nil {
+				if !strings.Contains(err.Error(), strconv.Itoa(http.StatusBadRequest)) {
+					t.Fatalf("DeployKeys.Create returned error: %v", err)
+				}
+				return
+			}
+
+			if (k.Key.Text != tt.key.Key.Text) || (k.Permission != tt.key.Permission) || (k.Repository.Slug != tt.key.Repository.Slug) {
+				t.Errorf("DeployKeys.Create returned:\n%v, want:\n%v", k, tt.key)
+			}
+		})
+	}
+}
+
+func TestUpdateKeyPermission(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        int
+		permission string
+	}{
+		{
+			name:       "test update to Writer",
+			key:        1,
+			permission: "REPO_WRITE",
+		},
+		{
+			name:       "test update to Admin",
+			key:        1,
+			permission: "REPO_ADMIN",
+		},
+		{
+			name:       "test update to REPO_BDFL",
+			key:        1,
+			permission: "REPO_REPO_BDFL",
+		},
+	}
+
+	mux, client := setup(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s/%s/%s/%s", stashURIkeys, projectsURI, RepositoriesURI, deployKeysURI, strconv.Itoa(tt.key), keyPermisionsURI, tt.permission)
+			mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPut {
+					req := &DeployKey{}
+					json.NewDecoder(r.Body).Decode(req)
+					switch path.Base(r.URL.String()) {
+					case "REPO_WRITE":
+						k := &DeployKey{
+							Key: Key{
+								ID:   1,
+								Text: req.Key.Text,
+							},
+							Permission: "REPO_WRITE",
+							Repository: Repository{
+								Slug: "repo1",
+								Project: Project{
+									Key: "prj1",
+								},
+							},
+						}
+						json.NewEncoder(w).Encode(k)
+						return
+					case "REPO_ADMIN":
+						k := &DeployKey{
+							Key: Key{
+								ID:   1,
+								Text: req.Key.Text,
+							},
+							Permission: "REPO_ADMIN",
+							Repository: Repository{
+								Slug: "repo1",
+								Project: Project{
+									Key: "prj1",
+								},
+							},
+						}
+						json.NewEncoder(w).Encode(k)
+						return
+					default:
+					}
+				}
+
+				http.Error(w, "The specified access key does not exist", http.StatusNotFound)
+
+				return
+
+			})
+			ctx := context.Background()
+			k, err := client.DeployKeys.UpdateKeyPermission(ctx, "prj1", "repo1", tt.key, tt.permission)
+			if err != nil {
+				if !strings.Contains(err.Error(), ErrNotFound.Error()) {
+					t.Fatalf("UpdateRepositoryGroupPermission returned error: %v", err)
+				}
+				return
+			}
+
+			if k.Permission != tt.permission {
+				t.Errorf("UpdateRepositoryGroupPermission returned:\n%v, want:\n%v", k, tt.permission)
+			}
+		})
+	}
+}

--- a/stash/groups_test.go
+++ b/stash/groups_test.go
@@ -31,7 +31,6 @@ func TestGetGroup(t *testing.T) {
 	tests := []struct {
 		name      string
 		groupName string
-		output    string
 	}{
 		{
 			name:      "test group does not exist",

--- a/stash/projects.go
+++ b/stash/projects.go
@@ -99,6 +99,10 @@ func (s *ProjectsService) List(ctx context.Context, opts *PagingOptions) (*Proje
 		return nil, ErrNotFound
 	}
 
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("list projects failed: %s", resp.Status)
+	}
+
 	p := &ProjectsList{
 		Projects: []*Project{},
 	}

--- a/stash/projects_test.go
+++ b/stash/projects_test.go
@@ -31,7 +31,6 @@ func TestGetProject(t *testing.T) {
 	tests := []struct {
 		name        string
 		projectName string
-		output      string
 	}{
 		{
 			name:        "test project does not exist",

--- a/stash/pull_requests.go
+++ b/stash/pull_requests.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	pullRequestsURI = "pull-requests"
+)
+
+// PullRequests interface defines the methods that can be used to
+// retrieve pull requests of a repository.
+type PullRequests interface {
+	Get(ctx context.Context, projectKey, repositorySlug string, prID int) (*PullRequest, error)
+	List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*PullRequestList, error)
+	Create(ctx context.Context, projectKey, repositorySlug string, pr *CreatePullRequest) (*PullRequest, error)
+	Update(ctx context.Context, projectKey, repositorySlug string, pr *PullRequest) (*PullRequest, error)
+	Delete(ctx context.Context, projectKey, repositorySlug string, IDVersion IDVersion) error
+}
+
+// PullRequestsService is a client for communicating with stash pull requests endpoint
+// bitbucket-server API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+type PullRequestsService service
+
+// Participant is a participant of a pull request
+type Participant struct {
+	// Approved indicates if the participant has approved the pull request
+	Approved bool `json:"approved,omitempty"`
+	// Role indicates the role of the participant
+	Role string `json:"role,omitempty"`
+	// Status indicates the status of the participant
+	Status string `json:"status,omitempty"`
+	// User is the participant
+	User `json:"user,omitempty"`
+}
+
+// Ref represents a git reference
+type Ref struct {
+	// DisplayID is the reference name
+	DisplayID string `json:"displayId,omitempty"`
+	// ID is the reference id i.e a git reference
+	ID string `json:"id,omitempty"`
+	// LatestCommit is the latest commit of the reference
+	LatestCommit string `json:"latestCommit,omitempty"`
+	// Repository is the repository of the reference
+	Repository `json:"repository,omitempty"`
+	// Type is the type of the reference
+	Type string `json:"type,omitempty"`
+}
+
+// CreatePullRequest creates a pull request from
+// a source branch or tag to a target branch.
+type CreatePullRequest struct {
+	// Closed indicates if the pull request is closed
+	Closed bool `json:"closed,omitempty"`
+	// Description is the description of the pull request
+	Description string `json:"description,omitempty"`
+	// FromRef is the source branch or tag
+	FromRef Ref `json:"fromRef,omitempty"`
+	// Locked indicates if the pull request is locked
+	Locked bool `json:"locked,omitempty"`
+	// Open indicates if the pull request is open
+	Open bool `json:"open,omitempty"`
+	// State is the state of the pull request
+	State string `json:"state,omitempty"`
+	// Title is the title of the pull request
+	Title string `json:"title,omitempty"`
+	// ToRef is the target branch
+	ToRef Ref `json:"toRef,omitempty"`
+	// Reviewers is the list of reviewers
+	Reviewers []User `json:"reviewers,omitempty"`
+}
+
+// IDVersion is a pull request id and version
+type IDVersion struct {
+	// ID is the id of the pull request
+	ID int `json:"id"`
+	// Version is the version of the pull request
+	Version int `json:"version"`
+}
+
+// PullRequest is a pull request
+type PullRequest struct {
+	// Session is the session of the pull request
+	Session `json:"sessionInfo,omitempty"`
+	// Author is the author of the pull request
+	Author Participant `json:"author,omitempty"`
+	// Closed indicates if the pull request is closed
+	Closed bool `json:"closed,omitempty"`
+	// CreatedDate is the creation date of the pull request
+	CreatedDate int64 `json:"createdDate,omitempty"`
+	// Description is the description of the pull request
+	Description string `json:"description,omitempty"`
+	// FromRef is the source branch or tag
+	FromRef Ref `json:"fromRef,omitempty"`
+	IDVersion
+	// Links is a set of hyperlinks that link to other related resources.
+	Links `json:"links,omitempty"`
+	// Locked indicates if the pull request is locked
+	Locked bool `json:"locked,omitempty"`
+	// Open indicates if the pull request is open
+	Open bool `json:"open,omitempty"`
+	// Participants are the participants of the pull request
+	Participants []Participant `json:"participants,omitempty"`
+	// Properties are the properties of the pull request
+	Properties Properties `json:"properties,omitempty"`
+	// Reviewers are the reviewers of the pull request
+	Reviewers []Participant `json:"reviewers,omitempty"`
+	// State is the state of the pull request
+	State string `json:"state,omitempty"`
+	// Title is the title of the pull request
+	Title string `json:"title,omitempty"`
+	// ToRef is the target branch
+	ToRef Ref `json:"toRef,omitempty"`
+	// UpdatedDate is the update date of the pull request
+	UpdatedDate int64 `json:"updatedDate,omitempty"`
+}
+
+// Properties are the properties of a pull request
+type Properties struct {
+	// MergeResult is the merge result of the pull request
+	MergeResult MergeResult `json:"mergeResult,omitempty"`
+	// OpenTaskCount is the number of open tasks
+	OpenTaskCount float64 `json:"openTaskCount,omitempty"`
+	// ResolvedTaskCount is the number of resolved tasks
+	ResolvedTaskCount float64 `json:"resolvedTaskCount,omitempty"`
+}
+
+// MergeResult is the merge result of a pull request
+type MergeResult struct {
+	// Current is the current merge result
+	Current bool `json:"current,omitempty"`
+	// Outcome is the outcome of the merge
+	Outcome string `json:"outcome,omitempty"`
+}
+
+// PullRequestList is a list of pull requests
+type PullRequestList struct {
+	// Paging is the paging information
+	Paging
+	// PullRequests are the pull requests
+	PullRequests []*PullRequest `json:"values,omitempty"`
+}
+
+// GetPullRequests returns a list of pull requests
+func (p *PullRequestList) GetPullRequests() []*PullRequest {
+	return p.PullRequests
+}
+
+// List returns the list of pull requests.
+// Paging is optional and is enabled by providing a PagingOptions struct.
+// A pointer to a PullRequestsList struct is returned to retrieve the next page of results.
+// List uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *PullRequestsService) List(ctx context.Context, projectKey, repositorySlug string, opts *PagingOptions) (*PullRequestList, error) {
+	query := addPaging(url.Values{}, opts)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, pullRequestsURI), WithQuery(query))
+	if err != nil {
+		return nil, fmt.Errorf("list pull requests request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list pull requests failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	p := &PullRequestList{}
+	if err := json.Unmarshal(res, p); err != nil {
+		return nil, fmt.Errorf("list pull requests failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	for _, r := range p.GetPullRequests() {
+		r.Session.set(resp)
+	}
+
+	return p, nil
+}
+
+// Get retrieves a pull request given it's ID.
+// Get uses the endpoint "GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}".
+// https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html
+func (s *PullRequestsService) Get(ctx context.Context, projectKey, repositorySlug string, prID int) (*PullRequest, error) {
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, pullRequestsURI, strconv.Itoa(prID)))
+	if err != nil {
+		return nil, fmt.Errorf("get pull request request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get pull request failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	p := &PullRequest{}
+	if err := json.Unmarshal(res, p); err != nil {
+		return nil, fmt.Errorf("get pull request failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	p.Session.set(resp)
+
+	return p, nil
+}
+
+// Create creates a pull request.
+// Create uses the endpoint "POST /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests".
+func (s *PullRequestsService) Create(ctx context.Context, projectKey, repositorySlug string, pr *CreatePullRequest) (*PullRequest, error) {
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	body, err := marshallBody(pr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall pull request: %v", err)
+	}
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, pullRequestsURI), WithBody(body), WithHeader(header))
+	if err != nil {
+		return nil, fmt.Errorf("create pull request request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("create pull request failed: %w", err)
+	}
+
+	p := &PullRequest{}
+	if err := json.Unmarshal(res, p); err != nil {
+		return nil, fmt.Errorf("create pull request failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	p.Session.set(resp)
+
+	return p, nil
+}
+
+// Update updates the pull request with the given ID
+// Update uses the endpoint "PUT /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}".
+func (s *PullRequestsService) Update(ctx context.Context, projectKey, repositorySlug string, pr *PullRequest) (*PullRequest, error) {
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	body, err := marshallBody(pr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall pull request: %v", err)
+	}
+	req, err := s.Client.NewRequest(ctx, http.MethodPut, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, pullRequestsURI, strconv.Itoa(pr.ID)), WithBody(body), WithHeader(header))
+	if err != nil {
+		return nil, fmt.Errorf("update pull request creation failed: %w", err)
+	}
+	res, resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("update pull failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	p := &PullRequest{}
+	if err := json.Unmarshal(res, p); err != nil {
+		return nil, fmt.Errorf("create pull request failed, unable to unmarshal repository list json: %w", err)
+	}
+
+	p.Session.set(resp)
+
+	return p, nil
+}
+
+// Delete deletes the pull request with the given ID
+// Delete uses the endpoint "DELETE /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}".
+// To call this resource, users must:
+// - be the pull request author, if the system is configured to allow authors to delete their own pull requests (this is the default) OR
+// - have repository administrator permission for the repository the pull request is targeting
+// A body containing the ID and version of the pull request must be provided with this request.
+// {
+//   "id": 1,
+//   "version": 1
+// }
+func (s *PullRequestsService) Delete(ctx context.Context, projectKey, repositorySlug string, IDVersion IDVersion) error {
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	body, err := marshallBody(IDVersion.Version)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, pullRequestsURI, strconv.Itoa(IDVersion.ID)), WithBody(body), WithHeader(header))
+	if err != nil {
+		return fmt.Errorf("delete pull request frequest creation failed: %w", err)
+	}
+	_, resp, err := s.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete pull request for repository failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+
+	return nil
+}

--- a/stash/pull_requests_test.go
+++ b/stash/pull_requests_test.go
@@ -1,0 +1,492 @@
+/*
+Copyright 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stash
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetPR(t *testing.T) {
+	tests := []struct {
+		name string
+		prID int
+	}{
+		{
+			name: "test a pull request",
+			prID: 101,
+		},
+		{
+			name: "test pull request does not exist",
+			prID: -1,
+		},
+	}
+
+	validPRID := []string{"101"}
+
+	mux, client := setup(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s/%s", stashURIprefix, projectsURI, RepositoriesURI, pullRequestsURI, strconv.Itoa(tt.prID))
+			mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+				for _, substr := range validPRID {
+					if path.Base(r.URL.String()) == substr {
+						w.WriteHeader(http.StatusOK)
+						c := &PullRequest{
+							IDVersion: IDVersion{
+								ID: 101,
+							},
+							Author: Participant{
+								User: User{
+									Name: "test",
+								},
+								Role: "AUTHOR",
+							},
+							FromRef: Ref{
+								ID: "refs/heads/feature-ABC-123",
+							},
+							ToRef: Ref{
+								ID: "refs/heads/main",
+							},
+							Properties: Properties{
+								MergeResult: MergeResult{
+									Current: true,
+									Outcome: "SUCCESS",
+								},
+							},
+						}
+
+						json.NewEncoder(w).Encode(c)
+						return
+					}
+				}
+
+				http.Error(w, "The specified pr does not exist", http.StatusNotFound)
+
+				return
+
+			})
+
+			ctx := context.Background()
+			c, err := client.PullRequests.Get(ctx, "prj1", "repo1", tt.prID)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Fatalf("PullRequest.Get returned error: %v", err)
+				}
+				return
+			}
+
+			if c.ID != tt.prID {
+				t.Fatalf("PullRequest.Get returned:\n%d, want:\n%d", c.ID, tt.prID)
+			}
+
+		})
+	}
+}
+
+func TestListPRs(t *testing.T) {
+	prIDs := []*PullRequest{
+		{IDVersion: IDVersion{ID: 101}},
+		{IDVersion: IDVersion{ID: 102}},
+		{IDVersion: IDVersion{ID: 103}},
+		{IDVersion: IDVersion{ID: 104}},
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj1/%s/repo1/%s", stashURIprefix, projectsURI, RepositoriesURI, pullRequestsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		b := struct {
+			PRs []*PullRequest `json:"values"`
+		}{[]*PullRequest{
+			prIDs[0],
+			prIDs[1],
+			prIDs[2],
+			prIDs[3],
+		}}
+		json.NewEncoder(w).Encode(b)
+		return
+
+	})
+	ctx := context.Background()
+	list, err := client.PullRequests.List(ctx, "prj1", "repo1", nil)
+	if err != nil {
+		t.Fatalf("PullRequests.List returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(prIDs, list.PullRequests); diff != "" {
+		t.Errorf("PullRequests.List returned diff (want -> got):\n%s", diff)
+	}
+
+}
+
+func TestCreatePR(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   CreatePullRequest
+	}{
+		{
+			name: "pr 1",
+			pr: CreatePullRequest{
+				Title:       "PR service",
+				Description: "A service that manages prs.",
+				State:       "OPEN",
+				Open:        true,
+				Closed:      false,
+				FromRef: Ref{
+					ID: "refs/heads/feature-pr",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				ToRef: Ref{
+					ID: "refs/heads/main",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				Locked: false,
+				Reviewers: []User{
+					{
+						Name: "charlie",
+					},
+				},
+			},
+		},
+		{
+			name: "pr 2",
+			pr: CreatePullRequest{
+				Title:       "PR service",
+				Description: "A service that manages prs.",
+				State:       "OPEN",
+				Open:        true,
+				Closed:      false,
+				FromRef: Ref{
+					ID: "refs/heads/feature-pr",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				ToRef: Ref{
+					ID: "refs/heads/main",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				Locked: false,
+				Reviewers: []User{
+					{
+						Name: "charlie",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid pr",
+			pr: CreatePullRequest{
+				Title:       "Invalid PR",
+				Description: "This PR is invalid because the ToRef and FromRef are the same branches.",
+				State:       "OPEN",
+				Open:        true,
+				Closed:      false,
+				FromRef: Ref{
+					ID: "refs/heads/main",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				ToRef: Ref{
+					ID: "refs/heads/main",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				Locked: false,
+				Reviewers: []User{
+					{
+						Name: "charlie",
+					},
+				},
+			},
+		},
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj/%s/my-repo/%s", stashURIprefix, projectsURI, RepositoriesURI, pullRequestsURI)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			req := &CreatePullRequest{}
+			json.NewDecoder(r.Body).Decode(req)
+			if req.FromRef.ID != req.ToRef.ID {
+				w.WriteHeader(http.StatusOK)
+				r := &PullRequest{
+					IDVersion: IDVersion{
+						ID:      1,
+						Version: 1,
+					},
+					CreatedDate: time.Now().Unix(),
+					UpdatedDate: time.Now().Unix(),
+					Title:       req.Title,
+					Description: req.Description,
+					State:       req.State,
+					Open:        req.Open,
+					Closed:      req.Closed,
+					FromRef:     req.FromRef,
+					ToRef:       req.ToRef,
+					Locked:      req.Locked,
+					Author: Participant{
+						User: User{
+							Name: "Rob",
+						},
+					},
+					Reviewers: []Participant{
+						{
+							User:     req.Reviewers[0],
+							Role:     "REVIEWER",
+							Approved: false,
+							Status:   "UNAPPROVED",
+						},
+					},
+				}
+				json.NewEncoder(w).Encode(r)
+				return
+			}
+		}
+
+		http.Error(w, "The pull request was not created due to same specified branches.", http.StatusConflict)
+
+		return
+
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			p, err := client.PullRequests.Create(ctx, "prj", "my-repo", &tt.pr)
+			if err != nil {
+				if !strings.Contains(err.Error(), "409 Conflict") {
+					t.Fatalf("PullRequest.Create returned error: %v", err)
+				}
+				return
+			}
+
+			if (p.Title != tt.pr.Title) || (p.FromRef.ID != tt.pr.FromRef.ID) || (p.ToRef.ID != tt.pr.ToRef.ID) {
+				t.Errorf("PullRequest.Create returned:\n%v, want:\n%v", p, tt.pr)
+			}
+		})
+	}
+}
+
+func TestUpdatePR(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+	}{
+		{
+			name: "update description",
+			pr: PullRequest{
+				IDVersion: IDVersion{
+					ID:      1,
+					Version: 2,
+				},
+				Title:       "PR service",
+				Description: "A service that manages prs. It supports get, list, create, update and deletes ops.",
+				ToRef: Ref{
+					ID: "refs/heads/main",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update destination branch",
+			pr: PullRequest{
+				IDVersion: IDVersion{
+					ID:      1,
+					Version: 3,
+				},
+				Title:       "PR service",
+				Description: "A service that manages prs. It supports get, list, create, update and deletes ops.",
+				ToRef: Ref{
+					ID: "refs/heads/develop",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("%s/%s/prj/%s/my-repo/%s/%s", stashURIprefix, projectsURI, RepositoriesURI, pullRequestsURI, strconv.Itoa(tests[0].pr.ID))
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			req := &PullRequest{}
+			json.NewDecoder(r.Body).Decode(req)
+			r := &PullRequest{
+				IDVersion: IDVersion{
+					ID:      req.ID,
+					Version: req.Version,
+				},
+				CreatedDate: time.Now().Unix(),
+				UpdatedDate: time.Now().Unix(),
+				Title:       req.Title,
+				Description: req.Description,
+				FromRef: Ref{
+					ID: "refs/heads/feature-pr",
+					Repository: Repository{
+						Slug: "my-repo",
+						Project: Project{
+							Key: "prj",
+						},
+					},
+				},
+				ToRef: req.ToRef,
+				Author: Participant{
+					User: User{
+						Name: "Rob",
+					},
+				},
+				Reviewers: []Participant{
+					{
+						User: User{
+							Name: "Charlie",
+						},
+						Role:     "REVIEWER",
+						Approved: false,
+						Status:   "UNAPPROVED",
+					},
+				},
+			}
+
+			w.WriteHeader(http.StatusOK)
+
+			json.NewEncoder(w).Encode(r)
+			return
+		}
+
+		http.Error(w, "The repository was not updated due to a validation error", http.StatusBadRequest)
+
+		return
+
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			p, err := client.PullRequests.Update(ctx, "prj", "my-repo", &tt.pr)
+			if err != nil {
+				t.Fatalf("PullRequests.Update returned error: %v", err)
+			}
+
+			if (p.Title != tt.pr.Title) || (p.Description != tt.pr.Description) || (p.ToRef.ID != tt.pr.ToRef.ID) {
+				t.Errorf("PullRequests.Update returned:\n%v, want:\n%v", p, tt.pr)
+			}
+		})
+	}
+}
+
+func TestDeletePR(t *testing.T) {
+	tests := []struct {
+		name      string
+		idVersion IDVersion
+	}{
+		{
+			name: "test PR does not exist",
+			idVersion: IDVersion{
+				ID:      -1,
+				Version: 2,
+			},
+		},
+		{
+			name: "test a PR",
+			idVersion: IDVersion{
+				ID:      1,
+				Version: 1,
+			},
+		},
+	}
+
+	mux, client := setup(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := fmt.Sprintf("%s/%s/prj/%s/my-repo/%s/%s", stashURIprefix, projectsURI, RepositoriesURI, pullRequestsURI, strconv.Itoa(tt.idVersion.ID))
+			mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+				id, err := strconv.ParseInt(path.Base(r.URL.String()), 10, 64)
+				if err != nil {
+					t.Fatalf("strconv.ParseInt returned error: %v", err)
+				}
+				if id >= 0 {
+					w.WriteHeader(http.StatusNoContent)
+					w.Write([]byte("204 - OK!"))
+					return
+				}
+
+				http.Error(w, "The specified repository or pull request does not exist.", http.StatusNotFound)
+
+				return
+
+			})
+			ctx := context.Background()
+			err := client.PullRequests.Delete(ctx, "prj", "my-repo", tt.idVersion)
+			if err != nil {
+				if err != ErrNotFound {
+					t.Errorf("PullRequests.Delete returned error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/stash/repositories.go
+++ b/stash/repositories.go
@@ -203,6 +203,10 @@ func (s *RepositoriesService) Create(ctx context.Context, repository *Repository
 		return nil, fmt.Errorf("create respository failed: %w", err)
 	}
 
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("create repository failed: %s", resp.Status)
+	}
+
 	repo := &Repository{}
 	if err := json.Unmarshal(res, repo); err != nil {
 		return nil, fmt.Errorf("create repository failed, unable to unmarshall repository json: %w", err)
@@ -232,6 +236,10 @@ func (s *RepositoriesService) Update(ctx context.Context, projectKey, repository
 
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("create deploy key for repository failed: %s", resp.Status)
 	}
 
 	repo := &Repository{}
@@ -372,6 +380,10 @@ func (s *RepositoriesService) UpdateRepositoryGroupPermission(ctx context.Contex
 
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return ErrNotFound
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusBadRequest {
+		return fmt.Errorf("add group permissions to repository failed: %s", resp.Status)
 	}
 
 	return nil

--- a/stash/repositories.go
+++ b/stash/repositories.go
@@ -171,9 +171,9 @@ func (s *RepositoriesService) Get(ctx context.Context, projectKey, repoSlug stri
 	return repo, nil
 }
 
-func marshallRepository(repo *Repository) (io.ReadCloser, error) {
+func marshallBody(b interface{}) (io.ReadCloser, error) {
 	var body io.ReadCloser
-	jsonBody, err := json.Marshal(repo)
+	jsonBody, err := json.Marshal(b)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func marshallRepository(repo *Repository) (io.ReadCloser, error) {
 // The authenticated user must have PROJECT_ADMIN permission for the context project to call this resource.
 func (s *RepositoriesService) Create(ctx context.Context, repository *Repository) (*Repository, error) {
 	header := http.Header{"Content-Type": []string{"application/json"}}
-	body, err := marshallRepository(repository)
+	body, err := marshallBody(repository)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshall repository: %v", err)
 	}
@@ -217,7 +217,7 @@ func (s *RepositoriesService) Create(ctx context.Context, repository *Repository
 // Update uses the endpoint "PUT /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}".
 func (s *RepositoriesService) Update(ctx context.Context, projectKey, repositorySlug string, repository *Repository) (*Repository, error) {
 	header := http.Header{"Content-Type": []string{"application/json"}}
-	body, err := marshallRepository(repository)
+	body, err := marshallBody(repository)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshall repository: %v", err)
 	}

--- a/stash/repositories_test.go
+++ b/stash/repositories_test.go
@@ -564,14 +564,12 @@ func TestUpdateRepositoryGroupsPermission(t *testing.T) {
 
 	mux, client := setup(t)
 
-	path := fmt.Sprintf("%s/%s/testProject/%s/repo1/%s", stashURIprefix, projectsURI, RepositoriesURI, groupPermisionsURI)
-	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+	p := fmt.Sprintf("%s/%s/testProject/%s/repo1/%s", stashURIprefix, projectsURI, RepositoriesURI, groupPermisionsURI)
+	mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
-			req := &RepositoryGroupPermission{}
-			json.NewDecoder(r.Body).Decode(req)
-			switch req.Permission {
-			case "Writer":
-			case "Admin":
+			switch r.URL.Query().Get("permission") {
+			case "REPO_WRITE":
+			case "REPO_ADMIN":
 			default:
 				http.Error(w, "The request was malformed or the specified permission does not exist", http.StatusBadRequest)
 				return
@@ -593,7 +591,7 @@ func TestUpdateRepositoryGroupsPermission(t *testing.T) {
 			ctx := context.Background()
 			err := client.Repositories.UpdateRepositoryGroupPermission(ctx, "testProject", "repo1", &tt.group)
 			if err != nil {
-				if !strings.Contains(err.Error(), "The request was malformed") {
+				if !strings.Contains(err.Error(), "400 Bad Request") {
 					t.Fatalf("UpdateRepositoryGroupPermission returned error: %v", err)
 				}
 				return

--- a/stash/resources.go
+++ b/stash/resources.go
@@ -24,7 +24,6 @@ const (
 	contextKey     = "context"
 	filterKey      = "filter"
 	stashURIprefix = "/rest/api/1.0"
-	stashURIkeys   = "/rest/keys/1.0"
 )
 
 // Session keeps a record of a request for a given user.

--- a/stash/users_test.go
+++ b/stash/users_test.go
@@ -54,9 +54,8 @@ func setup(t *testing.T) (*http.ServeMux, *Client) {
 
 func TestGetUser(t *testing.T) {
 	tests := []struct {
-		name   string
-		slug   string
-		output string
+		name string
+		slug string
 	}{
 		{
 			name: "test user does not exist",


### PR DESCRIPTION
#102 

Signed-off-by: Soule BA <soule@weave.works>

### Description

adds deployKeys  service to the stash client
deployKeys Service permits retrieving keys  and listing them for a given repository.

### Test results

https://github.com/souleb/go-git-providers/runs/3757881139?check_suite_focus=true
