### PR TITLE
Switch to "ListProjectMergeRequests" for GitLab

### DIFF
--- a/gitlab/client_repository_pullrequest.go
+++ b/gitlab/client_repository_pullrequest.go
@@ -39,7 +39,7 @@ type PullRequestClient struct {
 
 // List lists all pull requests in the repository
 func (c *PullRequestClient) List(ctx context.Context) ([]gitprovider.PullRequest, error) {
-	mrs, _, err := c.c.Client().MergeRequests.ListMergeRequests(nil)
+	mrs, _, err := c.c.Client().MergeRequests.ListProjectMergeRequests(getRepoPath(c.ref), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
-->
The support for listing GitLab pull requests (merge requests) is currently using `ListMergeRequests`. This returns all merge requests accessible by the authenticated user. We should instead be using `ListProjectMergeRequests` which scopes the query to a particular project (repository).


### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
```
arete: ~jj/go-git-providers> CGO_ENABLED=1 make test
go mod tidy
go fmt ./...
go vet ./...
go test  -race -coverprofile=coverage.txt -covermode=atomic ./...
?   	github.com/fluxcd/go-git-providers/bitbucket	[no test files]
ok  	github.com/fluxcd/go-git-providers/github	18.484s	coverage: 49.1% of statements
ok  	github.com/fluxcd/go-git-providers/gitlab	53.498s	coverage: 73.1% of statements
ok  	github.com/fluxcd/go-git-providers/gitprovider	0.038s	coverage: 92.2% of statements
?   	github.com/fluxcd/go-git-providers/gitprovider/cache	[no test files]
?   	github.com/fluxcd/go-git-providers/gitprovider/testutils	[no test files]
ok  	github.com/fluxcd/go-git-providers/stash	7.006s	coverage: 70.0% of statements
ok  	github.com/fluxcd/go-git-providers/validation	0.033s	coverage: 100.0% of statements
arete: ~jj/go-git-providers> 
```