### PR TITLE
[Stash] Add the logic to reconcile default branch.

### DIFF
--- a/stash/integration_repositories_org_test.go
+++ b/stash/integration_repositories_org_test.go
@@ -40,8 +40,7 @@ var _ = Describe("Stash Provider", func() {
 		Expect(repo.Repository()).To(Equal(expectedRepo))
 		Expect(*info.Description).To(Equal(defaultDescription))
 		Expect(*info.Visibility).To(Equal(gitprovider.RepositoryVisibilityPrivate))
-		// Stash does not provide the default as part of a repository api object
-		//Expect(*info.DefaultBranch).To(Equal(defaultBranch))
+		Expect(*info.DefaultBranch).To(Equal(defaultBranch))
 
 		// Expect high-level fields to match their underlying data
 		internal := repo.APIObject().(*Repository)
@@ -49,8 +48,7 @@ var _ = Describe("Stash Provider", func() {
 		Expect(repo.Repository().(gitprovider.Slugger).Slug()).To(Equal(internal.Slug))
 		Expect(repo.Repository().GetIdentity()).To(Equal(testOrgName))
 		Expect(*info.Visibility).To(Equal(gitprovider.RepositoryVisibilityPrivate))
-		// Stash does not provide the default as part of a repository api object
-		//Expect(*info.DefaultBranch).To(Equal(defaultBranch))
+		Expect(*info.DefaultBranch).To(Equal(defaultBranch))
 	}
 
 	It("should be possible to create an organization repo", func() {
@@ -81,7 +79,8 @@ var _ = Describe("Stash Provider", func() {
 		repo, err := client.OrgRepositories().Create(ctx, repoRef, gitprovider.RepositoryInfo{
 			Description: gitprovider.StringVar(defaultDescription),
 			// Default visibility is private, no need to set this at least now
-			Visibility: gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
 		}, &gitprovider.RepositoryCreateOptions{
 			AutoInit:        gitprovider.BoolVar(true),
 			LicenseTemplate: gitprovider.LicenseTemplateVar(gitprovider.LicenseTemplateApache2),
@@ -129,15 +128,15 @@ var _ = Describe("Stash Provider", func() {
 
 		// No-op reconcile
 		resp, actionTaken, err := client.OrgRepositories().Reconcile(ctx, repo.Repository().(gitprovider.OrgRepositoryRef), gitprovider.RepositoryInfo{
-			Description: gitprovider.StringVar(defaultDescription),
-			//DefaultBranch: gitprovider.StringVar(defaultBranch),
-			Visibility: gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			Description:   gitprovider.StringVar(defaultDescription),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
 		})
 
 		reflect.DeepEqual(repositoryFromAPI(resp.APIObject().(*Repository)), gitprovider.RepositoryInfo{
-			Description: gitprovider.StringVar(defaultDescription),
-			//DefaultBranch: gitprovider.StringVar(defaultBranch),
-			Visibility: gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			Description:   gitprovider.StringVar(defaultDescription),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
 		})
 
 		Expect(err).ToNot(HaveOccurred())
@@ -213,7 +212,8 @@ var _ = Describe("Stash Provider", func() {
 		repo, err := client.OrgRepositories().Create(ctx, sharedRepoRef, gitprovider.RepositoryInfo{
 			Description: gitprovider.StringVar(defaultDescription),
 			// Default visibility is private, no need to set this at least now
-			Visibility: gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
 		}, &gitprovider.RepositoryCreateOptions{
 			AutoInit:        gitprovider.BoolVar(true),
 			LicenseTemplate: gitprovider.LicenseTemplateVar(gitprovider.LicenseTemplateApache2),
@@ -368,17 +368,16 @@ var _ = Describe("Stash Provider", func() {
 
 		testRepoName = fmt.Sprintf("test-org-repo2-%03d", rand.Intn(1000))
 		repoRef := newOrgRepoRef(testOrg.Organization(), testRepoName)
-
-		defaultBranch := "master"
 		description := "test description"
 		// Create a new repo
 		orgRepo, err := client.OrgRepositories().Create(ctx, repoRef,
 			gitprovider.RepositoryInfo{
-				Description: &description,
-				Visibility:  gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+				Description:   &description,
+				Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+				DefaultBranch: gitprovider.StringVar(defaultBranch),
 			},
 			&gitprovider.RepositoryCreateOptions{
-				AutoInit: gitprovider.BoolVar(true),
+				AutoInit: gitprovider.BoolVar(false),
 			})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/stash/integration_repositories_user_test.go
+++ b/stash/integration_repositories_user_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Stash Provider", func() {
 		Expect(repo.Repository()).To(Equal(expectedRepoRef))
 		Expect(*info.Description).To(Equal(defaultDescription))
 		Expect(*info.Visibility).To(Equal(gitprovider.RepositoryVisibilityPrivate))
+		Expect(*info.DefaultBranch).To(Equal(defaultBranch))
 		// Expect high-level fields to match their underlying data
 		internal := repo.APIObject().(*Repository)
 		Expect(repo.Repository().GetRepository()).To(Equal(internal.Name))
@@ -46,6 +47,7 @@ var _ = Describe("Stash Provider", func() {
 		if !internal.Public {
 			Expect(*info.Visibility).To(Equal(gitprovider.RepositoryVisibilityPrivate))
 		}
+		Expect(*info.DefaultBranch).To(Equal(defaultBranch))
 	}
 
 	It("should be possible to create a user repo", func() {
@@ -70,7 +72,8 @@ var _ = Describe("Stash Provider", func() {
 		repo, err := client.UserRepositories().Create(ctx, repoRef, gitprovider.RepositoryInfo{
 			Description: gitprovider.StringVar(defaultDescription),
 			// Default visibility is private, no need to set this at least now
-			Visibility: gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
 		}, &gitprovider.RepositoryCreateOptions{
 			AutoInit:        gitprovider.BoolVar(true),
 			LicenseTemplate: gitprovider.LicenseTemplateVar(gitprovider.LicenseTemplateApache2),
@@ -106,9 +109,9 @@ var _ = Describe("Stash Provider", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// No-op reconcile
 		resp, actionTaken, err := client.UserRepositories().Reconcile(ctx, repo.Repository().(gitprovider.UserRepositoryRef), gitprovider.RepositoryInfo{
-			Description: gitprovider.StringVar(defaultDescription),
-			//DefaultBranch: gitprovider.StringVar(defaultBranchName),
-			Visibility: gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+			Description:   gitprovider.StringVar(defaultDescription),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actionTaken).To(BeFalse())
@@ -138,7 +141,8 @@ var _ = Describe("Stash Provider", func() {
 			var err error
 			// Reconcile and create
 			newRepo, actionTaken, err = client.UserRepositories().Reconcile(ctx, repoRef, gitprovider.RepositoryInfo{
-				Description: gitprovider.StringVar(defaultDescription),
+				Description:   gitprovider.StringVar(defaultDescription),
+				DefaultBranch: gitprovider.StringVar(defaultBranch),
 			}, &gitprovider.RepositoryCreateOptions{
 				AutoInit:        gitprovider.BoolVar(true),
 				LicenseTemplate: gitprovider.LicenseTemplateVar(gitprovider.LicenseTemplateMIT),
@@ -154,14 +158,13 @@ var _ = Describe("Stash Provider", func() {
 	It("should be possible to create a pr for a user repository", func() {
 		testRepoName = fmt.Sprintf("test-user-repo2-%03d", rand.Intn(1000))
 		repoRef := newUserRepoRef(stashUser, testRepoName)
-
-		defaultBranch := "master"
 		description := "test description"
 		// Create a new repo
 		userRepo, err := client.UserRepositories().Create(ctx, repoRef,
 			gitprovider.RepositoryInfo{
-				Description: &description,
-				Visibility:  gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+				Description:   &description,
+				Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+				DefaultBranch: gitprovider.StringVar(defaultBranch),
 			},
 			&gitprovider.RepositoryCreateOptions{
 				AutoInit: gitprovider.BoolVar(true),

--- a/stash/repositories.go
+++ b/stash/repositories.go
@@ -96,6 +96,8 @@ type Repository struct {
 	State string `json:"state,omitempty"`
 	// StatusMessage is the status message of the repository.
 	StatusMessage string `json:"statusMessage,omitempty"`
+	// DefaultBranch is the default branch of the repository.
+	DefaultBranch string `json:"defaultBranch,omitempty"`
 }
 
 // RepositoryList is a list of repositories

--- a/stash/resource_repository.go
+++ b/stash/resource_repository.go
@@ -100,7 +100,7 @@ func (r *userRepository) DeployKeys() gitprovider.DeployKeyClient {
 func (r *userRepository) Update(ctx context.Context) error {
 	// update by calling client
 	ref := r.ref.(gitprovider.UserRepositoryRef)
-	apiObj, err := update(ctx, r.c.client, addTilde(ref.UserLogin), ref.GetSlug(), &r.repository)
+	apiObj, err := update(ctx, r.c.client, addTilde(ref.UserLogin), ref.GetSlug(), &r.repository, "")
 	if err != nil {
 		// Log the error and return it
 		r.c.log.V(1).Error(err, "Error updating repository",
@@ -108,9 +108,10 @@ func (r *userRepository) Update(ctx context.Context) error {
 			"repo", r.Repository().GetRepository())
 		return err
 	}
-	r.repository = *apiObj
-	return nil
 
+	r.repository = *apiObj
+
+	return nil
 }
 
 // Reconcile makes sure the desired state in this object (called "req" here) becomes
@@ -196,7 +197,7 @@ func (r *orgRepository) Reconcile(ctx context.Context) (bool, error) {
 func (r *orgRepository) Update(ctx context.Context) error {
 	ref := r.ref.(gitprovider.OrgRepositoryRef)
 	// update by calling client
-	apiObj, err := update(ctx, r.c.client, ref.Key(), ref.Slug(), &r.repository)
+	apiObj, err := update(ctx, r.c.client, ref.Key(), ref.Slug(), &r.repository, "")
 	if err != nil {
 		// Log the error and return it
 		r.c.log.V(1).Error(err, "Error updating repository",
@@ -204,7 +205,9 @@ func (r *orgRepository) Update(ctx context.Context) error {
 			"repo", r.Repository().GetRepository())
 		return err
 	}
+
 	r.repository = *apiObj
+
 	return nil
 
 }
@@ -218,7 +221,8 @@ func (r *orgRepository) Delete(ctx context.Context) error {
 
 func repositoryFromAPI(apiObj *Repository) gitprovider.RepositoryInfo {
 	repo := gitprovider.RepositoryInfo{
-		Description: &apiObj.Description,
+		Description:   &apiObj.Description,
+		DefaultBranch: &apiObj.DefaultBranch,
 	}
 	repo.Visibility = gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate)
 	if apiObj.Public {
@@ -242,5 +246,9 @@ func repositoryInfoToAPIObj(repo *gitprovider.RepositoryInfo, apiObj *Repository
 	}
 	if repo.Visibility != nil {
 		apiObj.Public = *gitprovider.StringVar(string(*repo.Visibility)) == "true"
+	}
+
+	if repo.DefaultBranch != nil {
+		apiObj.DefaultBranch = *gitprovider.StringVar(*repo.DefaultBranch)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Soule BA <bah.soule@gmail.com>

### Description

The default branch is set at repository creation time  and updated at repository update time. It is save ad a field in the repository object and can thus be used to reconcile a repository.

Stash does not provide the ability to set default branch on repository creation and update.

A separate set of api calls is provided to manage branches.


### Test results

https://github.com/fluxcd/go-git-providers/runs/4035417362?check_suite_focus=true
