### PR TITLE
Use github search API for getting all user repos

### DIFF
--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -19,7 +19,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/google/go-github/v35/github"
@@ -238,9 +237,7 @@ func validateRepositoryObjects(apiObjs []*github.Repository) ([]*github.Reposito
 func (c *githubClientImpl) ListUserRepos(ctx context.Context, username string) ([]*github.Repository, error) {
 	var apiObjs []*github.Repository
 	opts := &github.SearchOptions{}
-	params := url.Values{}
-	params.Add("user", username)
-	queryStr := params.Encode()
+	queryStr := fmt.Sprintf("user:%s", username)
 
 	err := allPages(&opts.ListOptions, func() (*github.Response, error) {
 		// GET /search?q=user:{username}

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -341,6 +341,14 @@ var _ = Describe("GitHub Provider", func() {
 		getSpec := newGithubRepositorySpec(getUserRepo.APIObject().(*github.Repository))
 		postSpec := newGithubRepositorySpec(userRepo.APIObject().(*github.Repository))
 		Expect(getSpec.Equals(postSpec)).To(BeTrue())
+
+		Eventually(func() gitprovider.UserRepository {
+			// Expect that listing repositories from an authenticated user includes the new private repo
+			newRepos, err := c.UserRepositories().List(ctx, newUserRef(testUser))
+			Expect(err).ToNot(HaveOccurred())
+			newRepo := findUserRepo(newRepos, testUserRepoName)
+			return newRepo
+		}, 3*time.Second, 1*time.Second).ShouldNot(BeNil())
 	})
 
 	It("should error at creation time if the repo already does exist", func() {


### PR DESCRIPTION
Signed-off-by: Dinos Kousidis <dinos.simpson@gmail.com>

### Description

Closes #65 

Refactors the `ListUserRepos` method in the github client, to use the search API for getting public and private user repos.

### Test results

```
➜  github git:(65-gh-return-all-user-repos) ✗ go test ${TEST_VERBOSE} ${TEST_STOP_ON_ERROR} -race -coverprofile=coverage.txt -covermode=atomic ${TEST_PATTERN}
Running Suite: GitHub Provider Suite
====================================
Random Seed: 1637110248
Will run 8 of 8 specs

••
------------------------------
• [SLOW TEST:8.734 seconds]
GitHub Provider
/Users/dinos/go/src/github.com/fluxcd/go-git-providers/github/integration_test.go:129
  should be possible to create an org repository
  /Users/dinos/go/src/github.com/fluxcd/go-git-providers/github/integration_test.go:258
------------------------------
••reconcile user repository: test-repo-241, failed, error: multiple errors occurred: 
- PATCH https://api.github.com/repos/dinosk-test-org/test-repo-241: 404 Not Found []
- the requested resource was not found

------------------------------
• [SLOW TEST:5.270 seconds]
GitHub Provider
/Users/dinos/go/src/github.com/fluxcd/go-git-providers/github/integration_test.go:129
  should update if the repository already exists when reconciling
  /Users/dinos/go/src/github.com/fluxcd/go-git-providers/github/integration_test.go:360
------------------------------
•
------------------------------
• [SLOW TEST:8.155 seconds]
GitHub Provider
/Users/dinos/go/src/github.com/fluxcd/go-git-providers/github/integration_test.go:129
  should be possible to create a pr for a user repository
  /Users/dinos/go/src/github.com/fluxcd/go-git-providers/github/integration_test.go:437
------------------------------

Ran 8 of 8 Specs in 26.634 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
coverage: 49.7% of statements
ok  	github.com/fluxcd/go-git-providers/github	28.390s
```