### PR TITLE
[Stash] Revert log.Logger to v0.4.0 for compatibility with flux2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-logr/logr v1.1.0
-	github.com/go-logr/zapr v1.1.0
+	github.com/go-logr/logr v0.4.0
+	github.com/go-logr/zapr v0.4.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v35 v35.3.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,10 @@ github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2Su
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
-github.com/go-logr/logr v1.1.0 h1:nAbevmWlS2Ic4m4+/An5NXkaGqlqpbBgdcuThZxnZyI=
-github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/zapr v1.1.0 h1:rZHor2gcVGCG11UlKl+WUsfCMOOi2k/mTCDKDK6zZws=
-github.com/go-logr/zapr v1.1.0/go.mod h1:YShqdLLTU346TNVu8Tvwe3bOo6gc75oZ1joeE+1lYdQ=
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
+github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/zapr v0.4.0 h1:uc1uML3hRYL9/ZZPdgHS/n8Nzo+eaYL/Efxkkamf7OM=
+github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/stash/auth.go
+++ b/stash/auth.go
@@ -58,7 +58,7 @@ func NewStashClient(username, token string, optFns ...gitprovider.ClientOption) 
 		return nil, err
 	}
 
-	st, err := NewClient(client, host, nil, &logger, WithAuth(username, token))
+	st, err := NewClient(client, host, nil, logger, WithAuth(username, token))
 	if err != nil {
 		return nil, err
 	}

--- a/stash/client.go
+++ b/stash/client.go
@@ -95,7 +95,7 @@ type Client struct {
 	//HeaderFields is the header fields for all requests.
 	HeaderFields *http.Header
 	// Logger is the logger used to log the request and response.
-	Logger *logr.Logger
+	Logger logr.Logger
 	// username is the username for WithAuth.
 	username string
 	// Token used to make authenticated API calls.
@@ -149,11 +149,11 @@ func WithAuth(username string, token string) ClientOptionsFunc {
 //  		&http.Header {
 //  			"Content-Type": []string{"application/json"},
 //  		},
-//  		&logr.Logger{},
+//  		logr.Logger{},
 //  		func(c *Client) {
 //  			c.DisableRetries = true
 //  	})
-func NewClient(httpClient *http.Client, host string, header *http.Header, logger *logr.Logger, opts ...ClientOptionsFunc) (*Client, error) {
+func NewClient(httpClient *http.Client, host string, header *http.Header, logger logr.Logger, opts ...ClientOptionsFunc) (*Client, error) {
 	if host == "" {
 		return nil, errors.New("host is required")
 	}

--- a/stash/client_test.go
+++ b/stash/client_test.go
@@ -43,7 +43,7 @@ func Test_NewClient(t *testing.T) {
 		timeout   time.Duration
 		client    *http.Client
 		transport http.RoundTripper
-		log       *logr.Logger
+		log       logr.Logger
 		output    string
 	}{
 		{
@@ -53,7 +53,7 @@ func Test_NewClient(t *testing.T) {
 			timeout:   defaultTimeout,
 			client:    &http.Client{},
 			transport: defaultTransport,
-			log:       &logr.Logger{},
+			log:       logr.Discard(),
 			output:    "host is required",
 		},
 		{
@@ -63,12 +63,12 @@ func Test_NewClient(t *testing.T) {
 			timeout:   defaultTimeout,
 			client:    &http.Client{},
 			transport: defaultTransport,
-			log:       &logr.Logger{},
+			log:       logr.Discard(),
 			output:    `failed to parse host https://local#.@*dev to url, parse "https://local#.@*dev": net/url: invalid userinfo`,
 		},
 		{
 			name:   "default host",
-			log:    &logr.Logger{},
+			log:    logr.Discard(),
 			host:   fmt.Sprint("http://" + defaultHost),
 			output: fmt.Sprint("http://" + defaultHost),
 		}, {
@@ -331,11 +331,11 @@ func Test_DoWithRetry(t *testing.T) {
 	}
 }
 
-func initLogger(t *testing.T) *logr.Logger {
+func initLogger(t *testing.T) logr.Logger {
 	var log logr.Logger
 	zapLog := zaptest.NewLogger(t)
 	log = zapr.NewLogger(zapLog)
-	return &log
+	return log
 }
 
 // RoundTripFunc .


### PR DESCRIPTION
Signed-off-by: Soule BA <bah.soule@gmail.com>

### Description

Revert log.Logger to v0.4.0 for compatibility with flux2.
There is a breaking change from log.Logger v1.0.0...

I need this for the `flux bootstrap stash`

### Test results

https://github.com/fluxcd/go-git-providers/runs/4136936276?check_suite_focus=true
