### PR TITLE
[Stash] Fix SupportedDomain(), to make it return a host and not a full url

### DIFF
--- a/stash/auth_test.go
+++ b/stash/auth_test.go
@@ -32,23 +32,23 @@ func Test_DomainVariations(t *testing.T) {
 	}{
 		{
 			name: "custom domain without protocol",
-			opts: gitprovider.WithDomain("stash.stashtestserver.link"),
-			want: "https://stash.stashtestserver.link",
+			opts: gitprovider.WithDomain("stash.testserver.link"),
+			want: "stash.testserver.link",
 		},
 		{
 			name: "custom domain with port",
-			opts: gitprovider.WithDomain("stash.stashtestserver.link:7990"),
-			want: "https://stash.stashtestserver.link:7990",
+			opts: gitprovider.WithDomain("stash.testserver.link:8990"),
+			want: "stash.testserver.link:8990",
 		},
 		{
 			name: "custom domain with https protocol",
-			opts: gitprovider.WithDomain("https://stash.stashtestserver.link:7990"),
-			want: "https://stash.stashtestserver.link:7990",
+			opts: gitprovider.WithDomain("https://stash.testserver.link:8990"),
+			want: "stash.testserver.link:8990",
 		},
 		{
 			name: "custom domain with http protocol",
-			opts: gitprovider.WithDomain("http://stash.stashtestserver.link:7990"),
-			want: "http://stash.stashtestserver.link:7990",
+			opts: gitprovider.WithDomain("http://stash.testserver.link:8990"),
+			want: "stash.testserver.link:8990",
 		},
 	}
 	for _, tt := range tests {

--- a/stash/stash.go
+++ b/stash/stash.go
@@ -73,11 +73,11 @@ type ProviderClient struct {
 	userRepos *UserRepositoriesClient
 }
 
-// SupportedDomain returns the host endpoint for this client, e.g. "https://mystash.com:7990"
+// SupportedDomain returns the host endpoint for this client, e.g. "mystash.com:7990"
 // This allows a higher-level user to know what Client to use for what endpoints.
 // This field is set at client creation time, and can't be changed.
 func (p *ProviderClient) SupportedDomain() string {
-	return p.client.BaseURL.String()
+	return p.client.BaseURL.Host
 }
 
 // ProviderID returns the provider ID "gostash..


### PR DESCRIPTION

Signed-off-by: Soule BA <bah.soule@gmail.com>

### Description

Fix SupportedDomain(), to make it return a host and not a full url.


### Test results

https://github.com/fluxcd/go-git-providers/actions/runs/1436987613
