### PR TITLE
[Stash] Add methods to generate a clone url for a specific provider.

### DIFF
--- a/gitprovider/repositoryref.go
+++ b/gitprovider/repositoryref.go
@@ -279,8 +279,8 @@ func (r UserRepositoryRef) GetRepository() string {
 	return r.RepositoryName
 }
 
-// GetSlug returns the unique slug for this object.
-func (r UserRepositoryRef) GetSlug() string {
+// Slug returns the unique slug for this object.
+func (r UserRepositoryRef) Slug() string {
 	return r.slug
 }
 
@@ -309,16 +309,28 @@ func (r UserRepositoryRef) GetCloneURL(transport TransportType) string {
 func GetCloneURL(rs RepositoryRef, transport TransportType) string {
 	switch transport {
 	case TransportTypeHTTPS:
-		return fmt.Sprintf("%s.git", rs.String())
+		return ParseTypeHTTPS(rs.String())
 	case TransportTypeGit:
-		return fmt.Sprintf("git@%s:%s/%s.git", rs.GetDomain(), rs.GetIdentity(), rs.GetRepository())
+		return ParseTypeGit(rs.GetDomain(), rs.GetIdentity(), rs.GetRepository())
 	case TransportTypeSSH:
-		trimmedDomain := rs.GetDomain()
-		trimmedDomain = strings.Replace(trimmedDomain, "https://", "", -1)
-		trimmedDomain = strings.Replace(trimmedDomain, "http://", "", -1)
-		return fmt.Sprintf("ssh://git@%s/%s/%s", trimmedDomain, rs.GetIdentity(), rs.GetRepository())
+		return ParseTypeSSH(rs.GetDomain(), rs.GetIdentity(), rs.GetRepository())
 	}
 	return ""
+}
+
+func ParseTypeHTTPS(url string) string {
+	return fmt.Sprintf("%s.git", url)
+}
+
+func ParseTypeGit(domain, identity, repository string) string {
+	return fmt.Sprintf("git@%s:%s/%s.git", domain, identity, repository)
+}
+
+func ParseTypeSSH(domain, identity, repository string) string {
+	trimmedDomain := domain
+	trimmedDomain = strings.Replace(trimmedDomain, "https://", "", -1)
+	trimmedDomain = strings.Replace(trimmedDomain, "http://", "", -1)
+	return fmt.Sprintf("ssh://git@%s/%s/%s", trimmedDomain, identity, repository)
 }
 
 // ParseOrganizationURL parses an URL to an organization into a OrganizationRef object.

--- a/gitprovider/resources.go
+++ b/gitprovider/resources.go
@@ -87,6 +87,11 @@ type OrgRepository interface {
 	TeamAccess() TeamAccessClient
 }
 
+// CloneableURL returns the HTTPS URL to clone the repository.
+type CloneableURL interface {
+	GetCloneURL(prefix string, transport TransportType) string
+}
+
 // DeployKey represents a short-lived credential (e.g. an SSH public key) used to access a repository.
 type DeployKey interface {
 	// DeployKey implements the Object interface,

--- a/stash/client_repositories_user.go
+++ b/stash/client_repositories_user.go
@@ -47,7 +47,7 @@ func (c *UserRepositoriesClient) Get(ctx context.Context, ref gitprovider.UserRe
 		return nil, err
 	}
 
-	slug := ref.GetSlug()
+	slug := ref.Slug()
 	if slug == "" {
 		// try with name
 		slug = ref.GetRepository()
@@ -182,9 +182,9 @@ func (c *UserRepositoriesClient) reconcileRepository(ctx context.Context, actual
 	ref := actual.Repository().(gitprovider.UserRepositoryRef)
 	// Apply the desired state by running Update
 	if *req.DefaultBranch != "" && repo.DefaultBranch != *req.DefaultBranch {
-		_, err = update(ctx, c.client, addTilde(ref.UserLogin), ref.GetSlug(), repo, *req.DefaultBranch)
+		_, err = update(ctx, c.client, addTilde(ref.UserLogin), ref.Slug(), repo, *req.DefaultBranch)
 	} else {
-		_, err = update(ctx, c.client, addTilde(ref.UserLogin), ref.GetSlug(), repo, "")
+		_, err = update(ctx, c.client, addTilde(ref.UserLogin), ref.Slug(), repo, "")
 	}
 
 	if err != nil {

--- a/stash/integration_repositories_user_test.go
+++ b/stash/integration_repositories_user_test.go
@@ -83,6 +83,17 @@ var _ = Describe("Stash Provider", func() {
 		getRepoRef, err := client.UserRepositories().Get(ctx, repoRef)
 		Expect(err).ToNot(HaveOccurred())
 
+		// Verify that we can get clone url for the repo
+		if cloner, ok := getRepoRef.(gitprovider.CloneableURL); ok {
+			url := cloner.GetCloneURL("scm", gitprovider.TransportTypeHTTPS)
+			Expect(url).ToNot(BeEmpty())
+			fmt.Println("Clone URL: ", url)
+
+			sshURL := cloner.GetCloneURL("scm", gitprovider.TransportTypeSSH)
+			Expect(url).ToNot(BeEmpty())
+			fmt.Println("Clone ssh URL: ", sshURL)
+		}
+
 		validateUserRepo(repo, getRepoRef.Repository())
 
 		getRepo, err := client.UserRepositories().Get(ctx, repoRef)


### PR DESCRIPTION
Signed-off-by: Soule BA <bah.soule@gmail.com>

### Description

Each provider might have its own uri/path

An interface is added for each provider to implement. The interface defines a method to generate a clone url for a specific provider.

### Test results

-->](https://github.com/fluxcd/go-git-providers/actions/runs/1443790963)
