### PR TITLE
Ensure that the baseURL for the gitlab client includes a scheme

### DIFF
--- a/gitlab/auth_test.go
+++ b/gitlab/auth_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
+	gogitlab "github.com/xanzy/go-gitlab"
 )
 
-func Test_DomainVariations(t *testing.T) {
+func TestSupportedDomain(t *testing.T) {
 	tests := []struct {
 		name         string
 		opts         gitprovider.ClientOption
@@ -40,14 +41,29 @@ func Test_DomainVariations(t *testing.T) {
 			want: "https://my-gitlab.dev.com",
 		},
 		{
+			name: "custom domain without protocol with port",
+			opts: gitprovider.WithDomain("my-gitlab.dev.com:1234"),
+			want: "https://my-gitlab.dev.com:1234",
+		},
+		{
 			name: "custom domain with https protocol",
 			opts: gitprovider.WithDomain("https://my-gitlab.dev.com"),
 			want: "https://my-gitlab.dev.com",
 		},
 		{
+			name: "custom domain with https protocol with port",
+			opts: gitprovider.WithDomain("https://my-gitlab.dev.com:1234"),
+			want: "https://my-gitlab.dev.com:1234",
+		},
+		{
 			name: "custom domain with http protocol",
 			opts: gitprovider.WithDomain("http://my-gitlab.dev.com"),
 			want: "http://my-gitlab.dev.com",
+		},
+		{
+			name: "custom domain with http protocol with port",
+			opts: gitprovider.WithDomain("http://my-gitlab.dev.com:1234"),
+			want: "http://my-gitlab.dev.com:1234",
 		},
 	}
 	for _, tt := range tests {
@@ -57,6 +73,61 @@ func Test_DomainVariations(t *testing.T) {
 
 			c2, _ := NewClient("token", "pat", tt.opts)
 			assertEqual(t, tt.want, c2.SupportedDomain())
+		})
+	}
+}
+
+func TestBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     gitprovider.ClientOption
+		expected string
+	}{
+		{
+			name:     "gitlab.com domain",
+			opts:     gitprovider.WithDomain("gitlab.com"),
+			expected: "https://gitlab.com/api/v4/",
+		},
+		{
+			name:     "custom domain without protocol",
+			opts:     gitprovider.WithDomain("my-gitlab.dev.com"),
+			expected: "https://my-gitlab.dev.com/api/v4/",
+		},
+		{
+			name:     "custom domain without protocol with port",
+			opts:     gitprovider.WithDomain("my-gitlab.dev.com:1234"),
+			expected: "https://my-gitlab.dev.com:1234/api/v4/",
+		},
+		{
+			name:     "custom domain with https protocol",
+			opts:     gitprovider.WithDomain("https://my-gitlab.dev.com"),
+			expected: "https://my-gitlab.dev.com/api/v4/",
+		},
+		{
+			name:     "custom domain with https protocol with port",
+			opts:     gitprovider.WithDomain("https://my-gitlab.dev.com:1234"),
+			expected: "https://my-gitlab.dev.com:1234/api/v4/",
+		},
+		{
+			name:     "custom domain with http protocol",
+			opts:     gitprovider.WithDomain("http://my-gitlab.dev.com"),
+			expected: "http://my-gitlab.dev.com/api/v4/",
+		},
+		{
+			name:     "custom domain with http protocol with port",
+			opts:     gitprovider.WithDomain("http://my-gitlab.dev.com:1234"),
+			expected: "http://my-gitlab.dev.com:1234/api/v4/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c1, _ := NewClient("token", "oauth2", tt.opts)
+			gc1 := c1.Raw().(*gogitlab.Client)
+			assertEqual(t, tt.expected, gc1.BaseURL().String())
+
+			c2, _ := NewClient("token", "pat", tt.opts)
+			gc2 := c2.Raw().(*gogitlab.Client)
+			assertEqual(t, tt.expected, gc2.BaseURL().String())
 		})
 	}
 }

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
@@ -191,6 +192,17 @@ func validateOrganizationRef(ref gitprovider.OrganizationRef, expectedDomain str
 // validateIdentityFields makes sure the type of the IdentityRef is supported, and the domain is as expected.
 func validateIdentityFields(ref gitprovider.IdentityRef, expectedDomain string) error {
 	// Make sure the expected domain is used
+
+	// For custom domains ensure the expected domain only includes host
+	// and port information but not the scheme.
+	if expectedDomain != DefaultDomain {
+		d, err := url.Parse(expectedDomain)
+		if err != nil {
+			return err
+		}
+		expectedDomain = d.Host
+	}
+
 	if ref.GetDomain() != expectedDomain {
 		return fmt.Errorf("domain %q not supported by this client: %w", ref.GetDomain(), gitprovider.ErrDomainUnsupported)
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
-->
Fixes #135 

- Ensure that the baseURL for the gitlab client includes a scheme so that API calls succeed
- Fix validation for domain so that it uses the host part of the URL

### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
