### PR TITLE
Allow deleting files on gitlab

### DIFF
--- a/gitlab/client_repository_commit.go
+++ b/gitlab/client_repository_commit.go
@@ -70,16 +70,17 @@ func (c *CommitClient) Create(_ context.Context, branch string, message string, 
 		return nil, fmt.Errorf("no files added")
 	}
 
-	fileAction := gitlab.FileCreate
-
 	commitActions := make([]*gitlab.CommitActionOptions, 0)
 	for _, file := range files {
-		filePath := *file.Path
-		fileContent := *file.Content
+		fileAction := gitlab.FileCreate
+		if file.Content == nil {
+			fileAction = gitlab.FileDelete
+		}
+
 		commitActions = append(commitActions, &gitlab.CommitActionOptions{
 			Action:   &fileAction,
-			FilePath: &filePath,
-			Content:  &fileContent,
+			FilePath: file.Path,
+			Content:  file.Content,
 		})
 	}
 

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -729,7 +729,7 @@ var _ = Describe("GitLab Provider", func() {
 		validateUserRepo(newRepo, repoRef)
 	})
 
-	FIt("should be possible to create a pr for a user repository", func() {
+	It("should be possible to create a pr for a user repository", func() {
 
 		testRepoName = fmt.Sprintf("test-repo2-%03d", rand.Intn(1000))
 		repoRef := newUserRepoRef(testUserName, testRepoName)


### PR DESCRIPTION
- Follow github's approach and accept `nil` to signal file deletion

Fixes #137 