### PR TITLE
[Stash] Look for the exact projectName in the returned project list

### DIFF
--- a/stash/projects.go
+++ b/stash/projects.go
@@ -172,8 +172,16 @@ func (s *ProjectsService) Get(ctx context.Context, projectName string) (*Project
 		return nil, ErrNotFound
 	}
 
-	p.Projects[0].Session.set(resp)
-	return p.Projects[0], nil
+	// find the project
+	for i := range p.Projects {
+		if p.Projects[i].Name == projectName {
+			// Found!
+			p.Projects[i].Session.set(resp)
+			return p.Projects[i], nil
+		}
+	}
+
+	return nil, ErrNotFound
 
 }
 


### PR DESCRIPTION
When fetching a project by name, a list is returned. If implented, this
will make sure we return the right project from the list.

Ref: https://github.com/fluxcd/flux2/issues/2411

Signed-off-by: Soule BA <soule@weave.works>

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
-->


### Test results
(https://github.com/fluxcd/go-git-providers/runs/5157883730?check_suite_focus=true)
