### PR TITLE
Refactor update logic for github and upgrade to go-github v0.45.2

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -19,7 +19,7 @@ package github
 import (
 	"fmt"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client.go
+++ b/github/client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )
@@ -77,7 +77,7 @@ func (c *Client) ProviderID() gitprovider.ProviderID {
 	return ProviderID
 }
 
-// Raw returns the Go GitHub client (github.com/google/go-github/v42/github *Client)
+// Raw returns the Go GitHub client (github.com/google/go-github/v45/github *Client)
 // used under the hood for accessing GitHub.
 func (c *Client) Raw() interface{} {
 	return c.c.Client()

--- a/github/client_organization_teams.go
+++ b/github/client_organization_teams.go
@@ -19,7 +19,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repositories_org.go
+++ b/github/client_repositories_org.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repository_branch.go
+++ b/github/client_repository_branch.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 // BranchClient implements the gitprovider.BranchClient interface.

--- a/github/client_repository_commit.go
+++ b/github/client_repository_commit.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 var githubNewFileMode = "100644"

--- a/github/client_repository_deploykey.go
+++ b/github/client_repository_deploykey.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repository_file.go
+++ b/github/client_repository_file.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 // FileClient implements the gitprovider.FileClient interface.

--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 // PullRequestClient implements the gitprovider.PullRequestClient interface.

--- a/github/example_organization_test.go
+++ b/github/example_organization_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogithub "github.com/google/go-github/v42/github"
+	gogithub "github.com/google/go-github/v45/github"
 )
 
 // checkErr is used for examples in this repository.

--- a/github/example_repository_test.go
+++ b/github/example_repository_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogithub "github.com/google/go-github/v42/github"
+	gogithub "github.com/google/go-github/v45/github"
 )
 
 func ExampleOrgRepositoriesClient_Get() {

--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 // githubClientImpl is a wrapper around *github.Client, which implements higher-level methods,

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/gregjones/httpcache"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/github/resource_commit.go
+++ b/github/resource_commit.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/resource_deploykey.go
+++ b/github/resource_deploykey.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/resource_organization.go
+++ b/github/resource_organization.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/resource_pullrequest.go
+++ b/github/resource_pullrequest.go
@@ -18,7 +18,7 @@ package github
 
 import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 func newPullRequest(ctx *clientContext, apiObj *github.PullRequest) *pullrequest {

--- a/github/util.go
+++ b/github/util.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v45/github"
 )
 
 func Test_validateAPIObject(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/go-cmp v0.5.8
-	github.com/google/go-github/v42 v42.0.0
+	github.com/google/go-github/v45 v45.2.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/bradleyfalzon/ghinstallation/v2 v2.0.3/go.mod h1:tlgi+JWCXnKFx/Y4WtnDbZEINo31N5bcvnCoqieefmk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -88,7 +87,6 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -128,12 +126,10 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v39 v39.0.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
-github.com/google/go-github/v42 v42.0.0 h1:YNT0FwjPrEysRkLIiKuEfSvBPCGKphW5aS5PxwaoLec=
-github.com/google/go-github/v42 v42.0.0/go.mod h1:jgg/jvyI0YlDOM1/ps6XYh04HNQ3vKf0CVko62/EhRg=
+github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
+github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/stash/integration_suite_test.go
+++ b/stash/integration_suite_test.go
@@ -227,11 +227,9 @@ var _ = Describe("Stash Provider", func() {
 			return
 		}
 
-		if len(os.Getenv("CLEANUP_ALL")) > 0 {
-			defer cleanupOrgRepos(ctx, "test-org-repo")
-			defer cleanupOrgRepos(ctx, "test-shared-org-repo")
-			defer cleanupUserRepos(ctx, "test-user-repo")
-		}
+		defer cleanupOrgRepos(ctx, "test-org-repo")
+		defer cleanupOrgRepos(ctx, "test-shared-org-repo")
+		defer cleanupUserRepos(ctx, "test-user-repo")
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

Refactor update logic for github and upgrade to v0.45.2

If implemented, we now use reflect package to dynamically create and update github repositories before reconciliation.

### Test results

https://github.com/fluxcd/go-git-providers/runs/7021315747?check_suite_focus=true
