### PR TITLE
[Gitlab] do not always commit a readme as the autoInit error is not consistent

### DIFF
--- a/gitprovider/testutils/retry.go
+++ b/gitprovider/testutils/retry.go
@@ -33,6 +33,7 @@ type RetryI interface {
 	Interval() time.Duration
 	Backoff() time.Duration
 	Retries() int
+	Counter() int
 }
 
 // RetryOp is a retry operation
@@ -63,6 +64,11 @@ func (r RetryOp) Backoff() time.Duration {
 // Retries returns the number of retries for the retry operation
 func (r RetryOp) Retries() int {
 	return r.retries
+}
+
+// Counter returns the number of times the operation has been retried
+func (r RetryOp) Counter() int {
+	return r.counter
 }
 
 // SetTimeout sets the timeout for the retry operation


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

### Description

Still fixing the gitlab tests. This only commits a `readme` if a 404 code is return or no commit is found after a user repo is created with `autoInit`.


### Test results
https://github.com/fluxcd/go-git-providers/runs/8246455467?check_suite_focus=true
