### PR TITLE
Fix github reconcile method

### DIFF
--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -366,10 +366,12 @@ var _ = Describe("GitHub Provider", func() {
 
 		// Update reconcile
 		newDesc := "New description"
-		req := resp.Get()
-		req.Description = gitprovider.StringVar(newDesc)
-		Expect(resp.Set(req)).ToNot(HaveOccurred())
-		actionTaken, err = resp.Reconcile(ctx)
+		resp, actionTaken, err = c.OrgRepositories().Reconcile(ctx, repoRef, gitprovider.RepositoryInfo{
+			Description:   gitprovider.StringVar(newDesc),
+			DefaultBranch: gitprovider.StringVar(defaultBranch),
+			Visibility:    gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate),
+		})
+
 		// Expect the update to succeed, and modify the state
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actionTaken).To(BeTrue())


### PR DESCRIPTION
If applied this change makes sure that all reconcile methods take into account the patched update repo.

Signed-off-by: Soule BA <soule@weave.works>

### Description

In previous PR when refactoring to make sure github reconciliation methods do a proper patch when reconciling github repositories, we introduced a bug in the `Set()` method.

This PR update the needed code and modify the test code accordingly.


### Test results

https://github.com/fluxcd/go-git-providers/actions/runs/3043540139/jobs/4902916971
