### PR TITLE
Add API for editing pull requests

### DIFF
--- a/github/client_repository_file.go
+++ b/github/client_repository_file.go
@@ -19,7 +19,7 @@ package github
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/google/go-github/v47/github"
@@ -65,7 +65,7 @@ func (c *FileClient) Get(ctx context.Context, path, branch string, optFns ...git
 		if err != nil {
 			return nil, err
 		}
-		content, err := ioutil.ReadAll(output)
+		content, err := io.ReadAll(output)
 		if err != nil {
 			return nil, err
 		}

--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -66,6 +66,16 @@ func (c *PullRequestClient) Create(ctx context.Context, title, branch, baseBranc
 	return newPullRequest(c.clientContext, pr), nil
 }
 
+func (c *PullRequestClient) Edit(ctx context.Context, number int, opts gitprovider.EditOptions) (gitprovider.PullRequest, error) {
+	editPR := &github.PullRequest{}
+	editPR.Title = opts.Title
+	editedPR, _, err := c.c.Client().PullRequests.Edit(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), number, editPR)
+	if err != nil {
+		return nil, err
+	}
+	return newPullRequest(c.clientContext, editedPR), nil
+}
+
 // Get retrieves an existing pull request by number
 func (c *PullRequestClient) Get(ctx context.Context, number int) (gitprovider.PullRequest, error) {
 

--- a/gitlab/client_repositories_org.go
+++ b/gitlab/client_repositories_org.go
@@ -118,7 +118,7 @@ func (c *OrgRepositoriesClient) Reconcile(ctx context.Context, ref gitprovider.O
 	return actual, actionTaken, err
 }
 
-//nolint
+// nolint
 func createProject(ctx context.Context, c gitlabClient, ref gitprovider.RepositoryRef, groupName string, req gitprovider.RepositoryInfo, opts ...gitprovider.RepositoryCreateOption) (*gitlab.Project, error) {
 	// First thing, validate and default the request to ensure a valid and fully-populated object
 	// (to minimize any possible diffs between desired and actual state)

--- a/gitlab/client_repository_file.go
+++ b/gitlab/client_repository_file.go
@@ -19,7 +19,7 @@ package gitlab
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
@@ -72,7 +72,7 @@ func (c *FileClient) Get(ctx context.Context, path, branch string, optFns ...git
 		}
 		filePath := fileDownloaded.FilePath
 		fileContentDecoded := base64.NewDecoder(base64.RawStdEncoding, strings.NewReader(fileDownloaded.Content))
-		fileBytes, err := ioutil.ReadAll(fileContentDecoded)
+		fileBytes, err := io.ReadAll(fileContentDecoded)
 		if err != nil {
 			return nil, err
 		}

--- a/gitlab/client_repository_pullrequest.go
+++ b/gitlab/client_repository_pullrequest.go
@@ -71,6 +71,17 @@ func (c *PullRequestClient) Create(_ context.Context, title, branch, baseBranch,
 	return newPullRequest(c.clientContext, mr), nil
 }
 
+func (c *PullRequestClient) Edit(ctx context.Context, number int, opts gitprovider.EditOptions) (gitprovider.PullRequest, error) {
+	mrUpdate := &gitlab.UpdateMergeRequestOptions{
+		Title: opts.Title,
+	}
+	editedMR, _, err := c.c.Client().MergeRequests.UpdateMergeRequest(getRepoPath(c.ref), number, mrUpdate)
+	if err != nil {
+		return nil, err
+	}
+	return newPullRequest(c.clientContext, editedMR), nil
+}
+
 // Get retrieves an existing pull request by number
 func (c *PullRequestClient) Get(_ context.Context, number int) (gitprovider.PullRequest, error) {
 

--- a/gitlab/resource_repository.go
+++ b/gitlab/resource_repository.go
@@ -296,7 +296,7 @@ func (s *gitlabProjectSpec) Equals(other *gitlabProjectSpec) bool {
 	return cmp.Equal(s, other)
 }
 
-//nolint
+// nolint
 var gitlabVisibilityMap = map[gitprovider.RepositoryVisibility]gogitlab.VisibilityValue{
 	gitprovider.RepositoryVisibilityInternal: gogitlab.InternalVisibility,
 	gitprovider.RepositoryVisibilityPrivate:  gogitlab.PrivateVisibility,

--- a/gitlab/resource_teamaccess.go
+++ b/gitlab/resource_teamaccess.go
@@ -119,7 +119,7 @@ func (ta *teamAccess) Reconcile(ctx context.Context) (bool, error) {
 	return true, ta.Update(ctx)
 }
 
-//nolint
+// nolint
 var permissionPriority = map[int]gitprovider.RepositoryPermission{
 	10: gitprovider.RepositoryPermissionPull,
 	20: gitprovider.RepositoryPermissionTriage,

--- a/gitprovider/client.go
+++ b/gitprovider/client.go
@@ -231,10 +231,18 @@ type PullRequestClient interface {
 	List(ctx context.Context) ([]PullRequest, error)
 	// Create creates a pull request with the given specifications.
 	Create(ctx context.Context, title, branch, baseBranch, description string) (PullRequest, error)
+	// Edit allows for changing an existing pull request using the given options.
+	Edit(ctx context.Context, number int, opts EditOptions) (PullRequest, error)
 	// Get retrieves an existing pull request by number
 	Get(ctx context.Context, number int) (PullRequest, error)
 	// Merge merges a pull request with via either the "Squash" or "Merge" method
 	Merge(ctx context.Context, number int, mergeMethod MergeMethod, message string) error
+}
+
+// EditOptions is provided to a PullRequestClient's "Edit" method for updating an existing pull request.
+type EditOptions struct {
+	// Title is set to a non-nil value to request a pull request's title to be changed.
+	Title *string
 }
 
 // FileClient operates on the branches for a specific repository.

--- a/gitprovider/enums.go
+++ b/gitprovider/enums.go
@@ -49,6 +49,7 @@ const (
 )
 
 // knownRepositoryVisibilityValues is a map of known RepositoryVisibility values, used for validation.
+//
 //nolint:gochecknoglobals
 var knownRepositoryVisibilityValues = map[RepositoryVisibility]struct{}{
 	RepositoryVisibilityPublic:   {},
@@ -98,6 +99,7 @@ const (
 )
 
 // knownRepositoryVisibilityValues is a map of known RepositoryPermission values, used for validation.
+//
 //nolint:gochecknoglobals
 var knownRepositoryPermissionValues = map[RepositoryPermission]struct{}{
 	RepositoryPermissionPull:     {},
@@ -140,6 +142,7 @@ const (
 )
 
 // knownLicenseTemplateValues is a map of known LicenseTemplate values, used for validation
+//
 //nolint:gochecknoglobals
 var knownLicenseTemplateValues = map[LicenseTemplate]struct{}{
 	LicenseTemplateApache2: {},

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
+	k8s.io/utils v0.0.0-20221012122500-cfd413dd9e85
 )
 
 // Fix CVE-2022-28948

--- a/go.sum
+++ b/go.sum
@@ -254,3 +254,5 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/utils v0.0.0-20221012122500-cfd413dd9e85 h1:cTdVh7LYu82xeClmfzGtgyspNh6UxpwLWGi8R4sspNo=
+k8s.io/utils v0.0.0-20221012122500-cfd413dd9e85/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/stash/client.go
+++ b/stash/client.go
@@ -155,18 +155,19 @@ func WithAuth(username string, token string) ClientOptionsFunc {
 // If the http.Header is nil, a default http.Header is used.
 // ClientOptionsFunc is an optional function and can be used to configure the client.
 // Example:
-//  c, err := NewClient(
-//  	&http.Client {
-//  		Transport: defaultTransport,
-//  		Timeout:   defaultTimeout,
-//  		}, "https://github.com",
-//  		&http.Header {
-//  			"Content-Type": []string{"application/json"},
-//  		},
-//  		logr.Logger{},
-//  		func(c *Client) {
-//  			c.DisableRetries = true
-//  	})
+//
+//	c, err := NewClient(
+//		&http.Client {
+//			Transport: defaultTransport,
+//			Timeout:   defaultTimeout,
+//			}, "https://github.com",
+//			&http.Header {
+//				"Content-Type": []string{"application/json"},
+//			},
+//			logr.Logger{},
+//			func(c *Client) {
+//				c.DisableRetries = true
+//		})
 func NewClient(httpClient *http.Client, host string, header *http.Header, logger logr.Logger, opts ...ClientOptionsFunc) (*Client, error) {
 	if host == "" {
 		return nil, errors.New("host is required")

--- a/stash/client_test.go
+++ b/stash/client_test.go
@@ -346,7 +346,7 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-//NewTestClient returns a Client with Transport replaced to avoid making real calls
+// NewTestClient returns a Client with Transport replaced to avoid making real calls
 func NewTestClient(t *testing.T, fn RoundTripFunc, opts ...ClientOptionsFunc) *Client {
 	c, err := NewClient(nil, defaultHost, nil, initLogger(t))
 	if err != nil {

--- a/stash/deploy_keys.go
+++ b/stash/deploy_keys.go
@@ -219,7 +219,6 @@ func (s *DeployKeysService) Delete(ctx context.Context, projectKey, repositorySl
 
 // UpdateKeyPermission updates the given access key permission
 // UpdateKeyPermission uses the endpoint "PUT /rest/keys/1.0/projects/{projectKey}/ssh/{keyId}/permission/{permission}".
-//
 func (s *DeployKeysService) UpdateKeyPermission(ctx context.Context, projectKey, repositorySlug string, keyID int, permission string) (*DeployKey, error) {
 	req, err := s.Client.NewRequest(ctx, http.MethodPut, newKeysURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, deployKeysURI, strconv.Itoa(keyID),
 		keyPermisionsURI, permission))

--- a/stash/integration_repositories_user_test.go
+++ b/stash/integration_repositories_user_test.go
@@ -21,11 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"reflect"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/gitprovider/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Stash Provider", func() {
@@ -219,6 +221,15 @@ var _ = Describe("Stash Provider", func() {
 		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+
+		// Edit PR
+		pr, err = userRepo.PullRequests().Edit(ctx, pr.Get().Number, gitprovider.EditOptions{
+			Title: pointer.String("new title"),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		stashPR, ok := pr.APIObject().(*PullRequest)
+		Expect(ok).To(BeTrue(), "PR has unexpected type %s", reflect.TypeOf(pr.APIObject()))
+		Expect(stashPR.Title).To(Equal("new title"))
 
 		// List PRs
 		prs, err := userRepo.PullRequests().List(ctx)

--- a/stash/pull_requests.go
+++ b/stash/pull_requests.go
@@ -350,10 +350,11 @@ func (s *PullRequestsService) Merge(ctx context.Context, projectKey, repositoryS
 // - be the pull request author, if the system is configured to allow authors to delete their own pull requests (this is the default) OR
 // - have repository administrator permission for the repository the pull request is targeting
 // A body containing the ID and version of the pull request must be provided with this request.
-// {
-//   "id": 1,
-//   "version": 1
-// }
+//
+//	{
+//	  "id": 1,
+//	  "version": 1
+//	}
 func (s *PullRequestsService) Delete(ctx context.Context, projectKey, repositorySlug string, IDVersion IDVersion) error {
 	header := http.Header{"Content-Type": []string{"application/json"}}
 	body, err := marshallBody(IDVersion.Version)

--- a/stash/resource_organization.go
+++ b/stash/resource_organization.go
@@ -45,7 +45,7 @@ func (o *Organization) Organization() gitprovider.OrganizationRef {
 	return o.ref
 }
 
-//Teams gives access to the TeamsClient for this specific organization
+// Teams gives access to the TeamsClient for this specific organization
 func (o *Organization) Teams() gitprovider.TeamsClient {
 	return o.teams
 }

--- a/validation/multierror.go
+++ b/validation/multierror.go
@@ -35,26 +35,26 @@ func NewMultiError(errs ...error) *MultiError {
 // In order to check whether an error returned from a function was a
 // *MultiError, you can do:
 //
-// 		multiErr := &MultiError{}
-// 		if errors.Is(err, multiErr) { // do things }
+//	multiErr := &MultiError{}
+//	if errors.Is(err, multiErr) { // do things }
 //
 // In order to get the value of the *MultiError (embedded somewhere
 // in the chain, in order to access the sub-errors), you can do:
 //
-// 		multiErr := &MultiError{}
-// 		if errors.As(err, &multiErr) { // multiErr contains sub-errors, do things }
+//	multiErr := &MultiError{}
+//	if errors.As(err, &multiErr) { // multiErr contains sub-errors, do things }
 //
 // It is also possible to access sub-errors from a MultiError directly, using
 // errors.As and errors.Is. Example:
 //
-// 		multiErr := &MultiError{Errors: []error{ErrFieldRequired, ErrFieldInvalid}}
-//		if errors.Is(multiErr, ErrFieldInvalid) { // will return true, as ErrFieldInvalid is contained }
+//	multiErr := &MultiError{Errors: []error{ErrFieldRequired, ErrFieldInvalid}}
+//	if errors.Is(multiErr, ErrFieldInvalid) { // will return true, as ErrFieldInvalid is contained }
 //
-//		type customError struct { data string }
-//		func (e *customError) Error() string { return "custom" + data }
-// 		multiErr := &MultiError{Errors: []error{ErrFieldRequired, &customError{"my-value"}}}
-//		target := &customError{}
-//		if errors.As(multiErr, &target) { // target.data will now be "my-value" }
+//	type customError struct { data string }
+//	func (e *customError) Error() string { return "custom" + data }
+//	multiErr := &MultiError{Errors: []error{ErrFieldRequired, &customError{"my-value"}}}
+//	target := &customError{}
+//	if errors.As(multiErr, &target) { // target.data will now be "my-value" }
 type MultiError struct {
 	Errors []error
 }
@@ -104,6 +104,7 @@ func (e *MultiError) As(target interface{}) bool {
 
 // disallowedCompareAsErrorNames contains a list of which errors should NOT be compared for equality
 // using errors.As, as they could be very different errors although being the same type
+//
 //nolint:gochecknoglobals
 var disallowedCompareAsErrorNames = map[string]struct{}{
 	"*errors.errorString": {},


### PR DESCRIPTION
This commit adds an `Edit` method to the gitprovider.PullRequestClient
interface. Since the APIs for editing PRs/MRs vary widely between
providers, an `EditOptions` type is introduced for determining
specific fields to be edited.

Currently, only a pull request's title can be edited.

- [x] add `Edit` API method
- [x] add tests

closes #164
