### PR TITLE
add source branch name to pull request info

### DIFF
--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -479,6 +479,7 @@ var _ = Describe("GitHub Provider", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 		Expect(pr.Get().Merged).To(BeFalse())
+		Expect(pr.Get().SourceBranch).To(Equal(branchName))
 
 		prs, err := userRepo.PullRequests().List(ctx)
 		Expect(err).NotTo(HaveOccurred())

--- a/github/resource_pullrequest.go
+++ b/github/resource_pullrequest.go
@@ -45,9 +45,17 @@ func (pr *pullrequest) APIObject() interface{} {
 }
 
 func pullrequestFromAPI(apiObj *github.PullRequest) gitprovider.PullRequestInfo {
+	var sourceBranch string
+	head := apiObj.Head
+	if head != nil {
+		if head.Ref != nil {
+			sourceBranch = *head.Ref
+		}
+	}
 	return gitprovider.PullRequestInfo{
-		Merged: apiObj.GetMerged(),
-		Number: apiObj.GetNumber(),
-		WebURL: apiObj.GetHTMLURL(),
+		Merged:       apiObj.GetMerged(),
+		Number:       apiObj.GetNumber(),
+		WebURL:       apiObj.GetHTMLURL(),
+		SourceBranch: sourceBranch,
 	}
 }

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -829,9 +829,11 @@ var _ = Describe("GitLab Provider", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(prs)).To(Equal(1))
 		Expect(prs[0].Get().WebURL).To(Equal(pr.Get().WebURL))
+		Expect(prs[0].Get().SourceBranch).To(Equal(branchName))
 
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 		Expect(pr.Get().Merged).To(BeFalse())
+		Expect(pr.Get().SourceBranch).To(Equal(branchName))
 		err = userRepo.PullRequests().Merge(ctx, pr.Get().Number, gitprovider.MergeMethodSquash, "squash merged")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -865,6 +867,7 @@ var _ = Describe("GitLab Provider", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
 		Expect(pr.Get().Merged).To(BeFalse())
+		Expect(pr.Get().SourceBranch).To(Equal(branchName2))
 
 		editedPR, err := userRepo.PullRequests().Edit(ctx, pr.Get().Number, gitprovider.EditOptions{
 			Title: gitprovider.StringVar("a new title"),

--- a/gitlab/resource_pullrequest.go
+++ b/gitlab/resource_pullrequest.go
@@ -49,8 +49,9 @@ func (pr *pullrequest) APIObject() interface{} {
 
 func pullrequestFromAPI(apiObj *gitlab.MergeRequest) gitprovider.PullRequestInfo {
 	return gitprovider.PullRequestInfo{
-		Merged: apiObj.State == mergedState,
-		Number: apiObj.IID,
-		WebURL: apiObj.WebURL,
+		Merged:       apiObj.State == mergedState,
+		Number:       apiObj.IID,
+		WebURL:       apiObj.WebURL,
+		SourceBranch: apiObj.SourceBranch,
 	}
 }

--- a/gitprovider/types_repository.go
+++ b/gitprovider/types_repository.go
@@ -224,6 +224,9 @@ type PullRequestInfo struct {
 	// WebURL is the URL of the pull request in the git provider web interface.
 	// +required
 	WebURL string `json:"web_url"`
+
+	// SourceBranch is the branch from which the pull request has been created.
+	SourceBranch string `json:"source_branch"`
 }
 
 // TreeEntry contains info about each tree object's structure in TreeInfo whether it is a file or tree

--- a/stash/integration_repositories_org_test.go
+++ b/stash/integration_repositories_org_test.go
@@ -428,6 +428,7 @@ var _ = Describe("Stash Provider", func() {
 		pr, err := orgRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+		Expect(pr.Get().SourceBranch).To(Equal(branchName))
 	})
 })
 

--- a/stash/integration_repositories_user_test.go
+++ b/stash/integration_repositories_user_test.go
@@ -220,6 +220,7 @@ var _ = Describe("Stash Provider", func() {
 		pr, err := userRepo.PullRequests().Create(ctx, "Added config file", branchName, defaultBranch, "added config file")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pr.Get().WebURL).ToNot(BeEmpty())
+		Expect(pr.Get().SourceBranch).To(Equal(branchName))
 
 		editedPR, err := userRepo.PullRequests().Edit(ctx, pr.Get().Number, gitprovider.EditOptions{
 			Title: gitprovider.StringVar("a new title"),

--- a/stash/resource_pullrequest.go
+++ b/stash/resource_pullrequest.go
@@ -45,9 +45,10 @@ func (pr *pullrequest) APIObject() interface{} {
 
 func pullrequestFromAPI(apiObj *PullRequest) gitprovider.PullRequestInfo {
 	return gitprovider.PullRequestInfo{
-		WebURL: getSelfref(apiObj.Self),
-		Number: apiObj.ID,
-		Merged: apiObj.State == mergedState,
+		WebURL:       getSelfref(apiObj.Self),
+		Number:       apiObj.ID,
+		Merged:       apiObj.State == mergedState,
+		SourceBranch: apiObj.FromRef.DisplayID,
 	}
 }
 


### PR DESCRIPTION
This makes it much easier to identify a PR created from a certain local branch.
