### PR TITLE
fix deploy key test on v8.7.0

### DIFF
--- a/stash/integration_repositories_org_test.go
+++ b/stash/integration_repositories_org_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Stash Provider", func() {
 		// Get the test organization
 		orgRef := newOrgRef(testOrgName)
 		testOrg, err := client.Organizations().Get(ctx, orgRef)
-		//Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		//
 		testDeployKeyName := "test-deploy-key"
 		SharedRepoRef := newOrgRepoRef(testOrg.Organization(), testSharedOrgRepoName)
@@ -309,7 +309,7 @@ var _ = Describe("Stash Provider", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(keys)).To(Equal(0))
 
-		rsaGen := testutils.NewRSAGenerator(256)
+		rsaGen := testutils.NewRSAGenerator(2154)
 		keyPair1, err := rsaGen.Generate()
 		Expect(err).ToNot(HaveOccurred())
 		pubKey := keyPair1.PublicKey


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

### Description

We have upgraded our bitbucket test instance to v8.7.0 which add stricter controls on SSH keys. The tests case needed to be update to respect RSA keys length.

### Test results
https://github.com/fluxcd/go-git-providers/actions/runs/3948466900
