### PR TITLE
Implement client for Deploy Tokens

### DIFF
--- a/github/resource_repository.go
+++ b/github/resource_repository.go
@@ -129,6 +129,10 @@ func (r *userRepository) DeployKeys() gitprovider.DeployKeyClient {
 	return r.deployKeys
 }
 
+func (r *userRepository) DeployTokens() (gitprovider.DeployTokenClient, error) {
+	return nil, gitprovider.ErrNoProviderSupport
+}
+
 func (r *userRepository) Commits() gitprovider.CommitClient {
 	return r.commits
 }

--- a/gitlab/client_repository_deploytoken.go
+++ b/gitlab/client_repository_deploytoken.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/xanzy/go-gitlab"
+)
+
+// DeployTokenClient implements the gitprovider.DeployTokenClient interface.
+var _ gitprovider.DeployTokenClient = &DeployTokenClient{}
+
+// DeployTokenClient operates on the access deploy token list for a specific repository.
+type DeployTokenClient struct {
+	*clientContext
+	ref gitprovider.RepositoryRef
+}
+
+// Get returns the repository at the given path.
+//
+// ErrNotFound is returned if the resource does not exist.
+func (c *DeployTokenClient) Get(_ context.Context, deployTokenName string) (gitprovider.DeployToken, error) {
+	return c.get(deployTokenName)
+}
+
+func (c *DeployTokenClient) get(deployTokenName string) (*deployToken, error) {
+	deployTokens, err := c.list()
+	if err != nil {
+		return nil, err
+	}
+	// Loop through deploy tokens once we find one with the right name
+	for _, dk := range deployTokens {
+		if dk.k.Name == deployTokenName {
+			return dk, nil
+		}
+	}
+	return nil, gitprovider.ErrNotFound
+}
+
+// List lists all repository deploy tokens of the given deploy token type.
+//
+// List returns all available repository deploy tokens for the given type,
+// using multiple paginated requests if needed.
+func (c *DeployTokenClient) List(_ context.Context) ([]gitprovider.DeployToken, error) {
+	dks, err := c.list()
+	if err != nil {
+		return nil, err
+	}
+	// Cast to the generic []gitprovider.DeployToken
+	tokens := make([]gitprovider.DeployToken, 0, len(dks))
+	for _, dk := range dks {
+		tokens = append(tokens, dk)
+	}
+	return tokens, nil
+}
+
+func (c *DeployTokenClient) list() ([]*deployToken, error) {
+	// GET /repos/{owner}/{repo}/tokens
+	apiObjs, err := c.c.ListTokens(getRepoPath(c.ref))
+	if err != nil {
+		return nil, err
+	}
+
+	// Map the api object to our DeployToken type
+	tokens := make([]*deployToken, 0, len(apiObjs))
+	for _, apiObj := range apiObjs {
+		// apiObj is already validated at ListTokens
+		tokens = append(tokens, newDeployToken(c, apiObj))
+	}
+
+	return tokens, nil
+}
+
+// Create creates a deploy token with the given specifications.
+//
+// ErrAlreadyExists will be returned if the resource already exists.
+func (c *DeployTokenClient) Create(_ context.Context, req gitprovider.DeployTokenInfo) (gitprovider.DeployToken, error) {
+	apiObj, err := createDeployToken(c.c, c.ref, req)
+	if err != nil {
+		return nil, err
+	}
+	return newDeployToken(c, apiObj), nil
+}
+
+// Reconcile makes sure the given desired state (req) becomes the actual state in the backing Git provider.
+//
+// If req doesn't exist under the hood, it is created (actionTaken == true).
+// If req doesn't equal the actual state, the resource will be deleted and recreated (actionTaken == true).
+// If req is already the actual state, this is a no-op (actionTaken == false).
+func (c *DeployTokenClient) Reconcile(ctx context.Context, req gitprovider.DeployTokenInfo) (gitprovider.DeployToken, bool, error) {
+	// First thing, validate and default the request to ensure a valid and fully-populated object
+	// (to minimize any possible diffs between desired and actual state)
+	if err := gitprovider.ValidateAndDefaultInfo(&req); err != nil {
+		return nil, false, err
+	}
+
+	// Get the token with the desired name
+	actual, err := c.Get(ctx, req.Name)
+	if err != nil {
+		// Create if not found
+		if errors.Is(err, gitprovider.ErrNotFound) {
+			resp, err := c.Create(ctx, req)
+			return resp, true, err
+		}
+
+		// Unexpected path, Get should succeed or return NotFound
+		return nil, false, err
+	}
+
+	actionTaken, err := actual.Reconcile(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return actual, actionTaken, nil
+	//
+	// // If the desired matches the actual state, just return the actual state
+	// if req.Equals(actual.Get()) {
+	// 	return actual, false, nil
+	// }
+	//
+	// // Populate the desired state to the current-actual object
+	// if err := actual.Set(req); err != nil {
+	// 	return actual, false, err
+	// }
+	// // Apply the desired state by running Update
+	// return actual, true, actual.Update(ctx)
+}
+
+func createDeployToken(c gitlabClient, ref gitprovider.RepositoryRef, req gitprovider.DeployTokenInfo) (*gitlab.DeployToken, error) {
+	// First thing, validate and default the request to ensure a valid and fully-populated object
+	// (to minimize any possible diffs between desired and actual state)
+	if err := gitprovider.ValidateAndDefaultInfo(&req); err != nil {
+		return nil, err
+	}
+
+	return c.CreateToken(fmt.Sprintf("%s/%s", ref.GetIdentity(), ref.GetRepository()), deployTokenToAPI(&req))
+}

--- a/gitlab/client_repository_deploytoken.go
+++ b/gitlab/client_repository_deploytoken.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Flux CD contributors.
+Copyright 2023 The Flux CD contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/gitlab/resource_deploytoken.go
+++ b/gitlab/resource_deploytoken.go
@@ -94,9 +94,8 @@ func (dk *deployToken) Delete(_ context.Context) error {
 // Reconcile makes sure the desired state in this object (called "req" here) becomes
 // the actual state in the backing Git provider.
 //
-// If req doesn't exist under the hood, it is created (actionTaken == true).
-// If req doesn't equal the actual state, the resource will be updated (actionTaken == true).
-// If req is already the actual state, this is a no-op (actionTaken == false).
+// The deploy token cannot be retrieved from the GitLab,
+// consequently we have to re-create the deploy token in every reconcile call.
 //
 // The internal API object will be overridden with the received server data if actionTaken == true.
 func (dk *deployToken) Reconcile(ctx context.Context) (bool, error) {

--- a/gitlab/resource_deploytoken.go
+++ b/gitlab/resource_deploytoken.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2020 The Flux CD contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/xanzy/go-gitlab"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/fluxcd/go-git-providers/validation"
+)
+
+func newDeployToken(c *DeployTokenClient, token *gitlab.DeployToken) *deployToken {
+	return &deployToken{
+		k: *token,
+		c: c,
+	}
+}
+
+var _ gitprovider.DeployToken = &deployToken{}
+
+type deployToken struct {
+	k gitlab.DeployToken
+	c *DeployTokenClient
+}
+
+func (dk *deployToken) Get() gitprovider.DeployTokenInfo {
+	return deployTokenFromAPI(&dk.k)
+}
+
+func (dk *deployToken) Set(info gitprovider.DeployTokenInfo) error {
+	if err := info.ValidateInfo(); err != nil {
+		return err
+	}
+	deployTokenInfoToAPIObj(&info, &dk.k)
+	return nil
+}
+
+func (dk *deployToken) APIObject() interface{} {
+	return &dk.k
+}
+
+func (dk *deployToken) Repository() gitprovider.RepositoryRef {
+	return dk.c.ref
+}
+
+// Update will apply the desired state in this object to the server.
+// Only set fields will be respected (i.e. PATCH behaviour).
+// In order to apply changes to this object, use the .Set({Resource}Info) error
+// function, or cast .APIObject() to a pointer to the provider-specific type
+// and set custom fields there.
+//
+// ErrNotFound is returned if the resource does not exist.
+//
+// The internal API object will be overridden with the received server data.
+func (dk *deployToken) Update(ctx context.Context) error {
+	// Delete the old token and recreate
+	if err := dk.Delete(ctx); err != nil {
+		return err
+	}
+	return dk.createIntoSelf()
+}
+
+// Delete deletes a deploy token from the repository.
+//
+// ErrNotFound is returned if the resource does not exist.
+func (dk *deployToken) Delete(_ context.Context) error {
+	// We can use the same DeployToken ID that we got from the GET calls. Make sure it's non-nil.
+	// This _should never_ happen, but just check for it anyways to avoid panicing.
+	if dk.k.ID == 0 {
+		return fmt.Errorf("didn't expect ID to be 0: %w", gitprovider.ErrUnexpectedEvent)
+	}
+
+	return dk.c.c.DeleteToken(getRepoPath(dk.c.ref), dk.k.ID)
+}
+
+// Reconcile makes sure the desired state in this object (called "req" here) becomes
+// the actual state in the backing Git provider.
+//
+// If req doesn't exist under the hood, it is created (actionTaken == true).
+// If req doesn't equal the actual state, the resource will be updated (actionTaken == true).
+// If req is already the actual state, this is a no-op (actionTaken == false).
+//
+// The internal API object will be overridden with the received server data if actionTaken == true.
+func (dk *deployToken) Reconcile(ctx context.Context) (bool, error) {
+	// Always update for now.
+	// The problem here is that there is no way to retrieve the secret token value
+	// from GitLab again, so we'll never be sure if it actually matches what we have
+	// in this deployToken, so lets just update.
+	return true, dk.Update(ctx)
+}
+
+func (dk *deployToken) createIntoSelf() error {
+	// POST /repos/{owner}/{repo}/tokens
+	apiObj, err := dk.c.c.CreateToken(getRepoPath(dk.c.ref), &dk.k)
+	if err != nil {
+		return err
+	}
+	dk.k = *apiObj
+	return nil
+}
+
+func validateDeployTokenAPI(apiObj *gitlab.DeployToken) error {
+	return validateAPIObject("GitLab.Token", func(validator validation.Validator) {
+		if apiObj.Name == "" {
+			validator.Required("Name")
+		}
+		if apiObj.Username == "" {
+			validator.Required("Username")
+		}
+	})
+}
+
+func deployTokenFromAPI(apiObj *gitlab.DeployToken) gitprovider.DeployTokenInfo {
+	return gitprovider.DeployTokenInfo{
+		Name:     apiObj.Name,
+		Username: apiObj.Username,
+		Token:    apiObj.Token,
+	}
+}
+
+func deployTokenToAPI(info *gitprovider.DeployTokenInfo) *gitlab.DeployToken {
+	k := &gitlab.DeployToken{}
+	deployTokenInfoToAPIObj(info, k)
+	return k
+}
+
+func deployTokenInfoToAPIObj(info *gitprovider.DeployTokenInfo, apiObj *gitlab.DeployToken) {
+	// Required fields, we assume info is validated, and hence these are set
+	apiObj.Name = info.Name
+	apiObj.Username = info.Username
+}
+
+// This function copies over the fields that are part of create request of a deploy
+// i.e. the desired spec of the deploy token. This allows us to separate "spec" from "status" fields.
+func newGitlabTokenSpec(token *gitlab.DeployToken) *gitlabTokenSpec {
+	return &gitlabTokenSpec{
+		&gitlab.DeployToken{
+			// Create-specific parameters
+			Name: token.Name,
+		},
+	}
+}
+
+type gitlabTokenSpec struct {
+	*gitlab.DeployToken
+}
+
+func (s *gitlabTokenSpec) Equals(other *gitlabTokenSpec) bool {
+	return reflect.DeepEqual(s, other)
+}

--- a/gitlab/resource_deploytoken.go
+++ b/gitlab/resource_deploytoken.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Flux CD contributors.
+Copyright 2023 The Flux CD contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/gitlab/resource_repository.go
+++ b/gitlab/resource_repository.go
@@ -35,6 +35,10 @@ func newUserProject(ctx *clientContext, apiObj *gogitlab.Project, ref gitprovide
 			clientContext: ctx,
 			ref:           ref,
 		},
+		deployTokens: &DeployTokenClient{
+			clientContext: ctx,
+			ref:           ref,
+		},
 		commits: &CommitClient{
 			clientContext: ctx,
 			ref:           ref,
@@ -67,6 +71,7 @@ type userProject struct {
 	ref gitprovider.RepositoryRef
 
 	deployKeys   *DeployKeyClient
+	deployTokens *DeployTokenClient
 	commits      *CommitClient
 	branches     *BranchClient
 	pullRequests *PullRequestClient
@@ -96,6 +101,10 @@ func (p *userProject) Repository() gitprovider.RepositoryRef {
 
 func (p *userProject) DeployKeys() gitprovider.DeployKeyClient {
 	return p.deployKeys
+}
+
+func (p *userProject) DeployTokens() (gitprovider.DeployTokenClient, error) {
+	return p.deployTokens, nil
 }
 
 func (p *userProject) Commits() gitprovider.CommitClient {

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -116,6 +116,19 @@ func allDeployKeyPages(opts *gitlab.ListProjectDeployKeysOptions, fn func() (*gi
 	}
 }
 
+func allDeployTokenPages(opts *gitlab.ListProjectDeployTokensOptions, fn func() (*gitlab.Response, error)) error {
+	for {
+		resp, err := fn()
+		if err != nil {
+			return err
+		}
+		if resp.NextPage == 0 {
+			return nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
 // validateUserRepositoryRef makes sure the UserRepositoryRef is valid for GitHub's usage.
 func validateUserRepositoryRef(ref gitprovider.UserRepositoryRef, expectedDomain string) error {
 	// Make sure the RepositoryRef fields are valid

--- a/gitprovider/client.go
+++ b/gitprovider/client.go
@@ -207,6 +207,33 @@ type DeployKeyClient interface {
 	Reconcile(ctx context.Context, req DeployKeyInfo) (resp DeployKey, actionTaken bool, err error)
 }
 
+// DeployTokenClient operates on the deploy token list of a specific repository.
+// This client can be accessed through Repository.DeployTokens().
+type DeployTokenClient interface {
+	// Get a DeployToken by its name.
+	//
+	// ErrNotFound is returned if the resource does not exist.
+	Get(ctx context.Context, name string) (DeployToken, error)
+
+	// List all deploy tokens for the given repository.
+	//
+	// List returns all available deploy tokens for the given type,
+	// using multiple paginated requests if needed.
+	List(ctx context.Context) ([]DeployToken, error)
+
+	// Create a deploy token with the given specifications.
+	//
+	// ErrAlreadyExists will be returned if the resource already exists.
+	Create(ctx context.Context, req DeployTokenInfo) (DeployToken, error)
+
+	// Reconcile makes sure the given desired state (req) becomes the actual state in the backing Git provider.
+	//
+	// If req doesn't exist under the hood, it is created (actionTaken == true).
+	// If req doesn't equal the actual state, the resource will be updated (actionTaken == true).
+	// If req is already the actual state, this is a no-op (actionTaken == false).
+	Reconcile(ctx context.Context, req DeployTokenInfo) (resp DeployToken, actionTaken bool, err error)
+}
+
 // CommitClient operates on the commits list for a specific repository.
 // This client can be accessed through Repository.Commits().
 type CommitClient interface {

--- a/gitprovider/resources.go
+++ b/gitprovider/resources.go
@@ -68,6 +68,10 @@ type UserRepository interface {
 	// DeployKeys gives access to manipulating deploy keys to access this specific repository.
 	DeployKeys() DeployKeyClient
 
+	// DeployTokens gives access to manipulating deploy tokens to access this specific repository.
+	// Returns "ErrNoProviderSupport" if the provider doesn't support deploy tokens.
+	DeployTokens() (DeployTokenClient, error)
+
 	// Commits gives access to this specific repository commits
 	Commits() CommitClient
 
@@ -117,6 +121,27 @@ type DeployKey interface {
 	// Set sets high-level desired state for this deploy key. In order to apply these changes in
 	// the Git provider, run .Update() or .Reconcile().
 	Set(DeployKeyInfo) error
+}
+
+// DeployToken represents a short-lived credential used to access a repository.
+type DeployToken interface {
+	// DeployToken implements the Object interface,
+	// allowing access to the underlying object returned from the API.
+	Object
+	// The deploy token can be updated.
+	Updatable
+	// The deploy token can be reconciled.
+	Reconcilable
+	// The deploy token can be deleted.
+	Deletable
+	// RepositoryBound returns repository reference details.
+	RepositoryBound
+
+	// Get returns high-level information about this deploy token.
+	Get() DeployTokenInfo
+	// Set sets high-level desired state for this deploy token. In order to apply these changes in
+	// the Git provider, run .Update() or .Reconcile().
+	Set(DeployTokenInfo) error
 }
 
 // TeamAccess describes a binding between a repository and a team.

--- a/gitprovider/types_repository.go
+++ b/gitprovider/types_repository.go
@@ -179,6 +179,47 @@ func (dk DeployKeyInfo) Equals(actual InfoRequest) bool {
 	return reflect.DeepEqual(dk, actual)
 }
 
+// DeployTokenInfo implements InfoRequest and DefaultedInfoRequest (with a pointer receiver).
+var _ InfoRequest = DeployTokenInfo{}
+var _ DefaultedInfoRequest = &DeployTokenInfo{}
+
+// DeployTokenInfo contains high-level information about a deploy token.
+type DeployTokenInfo struct {
+	// Name is the human-friendly interpretation of what the token is for (and does).
+	// +required
+	Name string `json:"name"`
+
+	// Username is the generated Deploy Token Username by the API
+	// +optional
+	Username string `json:"username"`
+
+	// Token is the generated Deploy Token by the API
+	// +optional
+	Token string `json:"token"`
+}
+
+// Default defaults the DeployToken fields.
+func (dk *DeployTokenInfo) Default() {
+}
+
+// ValidateInfo validates the object at {Object}.Set() and POST-time.
+func (dk DeployTokenInfo) ValidateInfo() error {
+	validator := validation.New("DeployToken")
+	// Make sure we've set the name of the deploy token
+	if len(dk.Name) == 0 {
+		validator.Required("Name")
+	}
+	// Don't care about the RepositoryRef, as that information is coming from
+	// the RepositoryClient. In the client, we make sure that they equal.
+	return validator.Error()
+}
+
+// Equals can be used to check if this *Info request (the desired state) matches the actual
+// passed in as the argument.
+func (dk DeployTokenInfo) Equals(actual InfoRequest) bool {
+	return reflect.DeepEqual(dk, actual)
+}
+
 // CommitInfo contains high-level information about a deploy key.
 type CommitInfo struct {
 	// Sha is the git sha for this commit.

--- a/gitprovider/types_validation_test.go
+++ b/gitprovider/types_validation_test.go
@@ -79,6 +79,31 @@ func TestDeployKey_Validate(t *testing.T) {
 	}
 }
 
+func TestDeployToken_Validate(t *testing.T) {
+	tests := []struct {
+		name         string
+		token        DeployTokenInfo
+		expectedErrs []error
+	}{
+		{
+			name: "valid create",
+			token: DeployTokenInfo{
+				Name: "foo-deploytoken",
+			},
+		},
+		{
+			name:         "invalid create, missing name",
+			token:        DeployTokenInfo{},
+			expectedErrs: []error{validation.ErrFieldRequired},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidation(t, "DeployToken", tt.token.ValidateInfo, tt.expectedErrs)
+		})
+	}
+}
+
 func TestRepository_Validate(t *testing.T) {
 	unknownRepositoryVisibility := RepositoryVisibility("unknown")
 	tests := []struct {

--- a/stash/resource_repository.go
+++ b/stash/resource_repository.go
@@ -117,6 +117,10 @@ func (r *userRepository) DeployKeys() gitprovider.DeployKeyClient {
 	return r.deployKeys
 }
 
+func (r *userRepository) DeployTokens() (gitprovider.DeployTokenClient, error) {
+	return nil, gitprovider.ErrNoProviderSupport
+}
+
 // The internal API object will be overridden with the received server data.
 func (r *userRepository) Update(ctx context.Context) error {
 	// update by calling client


### PR DESCRIPTION
### Description

This change set implements a `DeployTokenClient` and the associated resource to support GitLab Deploy Tokens in the Flux CLI.

See related discussion here: https://github.com/fluxcd/flux2/discussions/3595
GitLab Issue here: https://gitlab.com/gitlab-org/gitlab/-/issues/392605

Prerequisite for this to merge is a new release from `go-gitlab` and update in this package which includes:

- https://github.com/xanzy/go-gitlab/pull/1662

### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
