### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,14 @@ jobs:
       - name: Restore Go cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          go-version: 1.18
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: 1.18.x
       - name: Download release notes utility
         env:
           GH_REL_URL: https://github.com/buchanae/github-release-notes/releases/download/0.2.0/github-release-notes-linux-amd64-0.2.0.tar.gz


### PR DESCRIPTION
The workflow has been updated in #197 but is failing now with:

```
[warning]Unexpected input(s) 'go-version', valid inputs are ['path', 'key', 'restore-keys', 'upload-chunk-size', 'enableCrossOsArchive', 'fail-on-cache-miss', 'lookup-only']
[group]Run actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
with:
  go-version: 1.18
  enableCrossOsArchive: false
  fail-on-cache-miss: false
  lookup-only: false
[endgroup]
[error]Input required and not supplied: key
```
