### PR TITLE
Update dependencies and github workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Run vet
         run: make tidy fmt vet
       - name: Check if working tree is dirty

--- a/.github/workflows/e2e-github.yaml
+++ b/.github/workflows/e2e-github.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Run tests
         run: |
           [ -n "${{ secrets.GITPROVIDER_BOT_TOKEN }}" ] && export GITHUB_TOKEN=${{ secrets.GITPROVIDER_BOT_TOKEN }} || echo "using default GITHUB_TOKEN"

--- a/.github/workflows/e2e-gitlab.yaml
+++ b/.github/workflows/e2e-gitlab.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Start Provider instances
         run: make start-provider-instances GITLAB_VERSION=latest
       - name: Run tests [gitlab]

--- a/.github/workflows/e2e-stash.yaml
+++ b/.github/workflows/e2e-stash.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Run tests
         run: |
           [ -n "${{ secrets.STASH_TOKEN }}" ] && export STASH_TOKEN=${{ secrets.STASH_TOKEN }} || echo "using default STASH_TOKEN"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Download release notes utility
         env:
           GH_REL_URL: https://github.com/buchanae/github-release-notes/releases/download/0.2.0/github-release-notes-linux-amd64-0.2.0.tar.gz

--- a/github/auth.go
+++ b/github/auth.go
@@ -19,7 +19,7 @@ package github
 import (
 	"fmt"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client.go
+++ b/github/client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_organization_teams.go
+++ b/github/client_organization_teams.go
@@ -19,7 +19,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repositories_org.go
+++ b/github/client_repositories_org.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repository_branch.go
+++ b/github/client_repository_branch.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 // BranchClient implements the gitprovider.BranchClient interface.

--- a/github/client_repository_commit.go
+++ b/github/client_repository_commit.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 var githubNewFileMode = "100644"

--- a/github/client_repository_deploykey.go
+++ b/github/client_repository_deploykey.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repository_file.go
+++ b/github/client_repository_file.go
@@ -22,7 +22,7 @@ import (
 	"io"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 // FileClient implements the gitprovider.FileClient interface.

--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 // PullRequestClient implements the gitprovider.PullRequestClient interface.

--- a/github/example_organization_test.go
+++ b/github/example_organization_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogithub "github.com/google/go-github/v49/github"
+	gogithub "github.com/google/go-github/v52/github"
 )
 
 // checkErr is used for examples in this repository.

--- a/github/example_repository_test.go
+++ b/github/example_repository_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogithub "github.com/google/go-github/v49/github"
+	gogithub "github.com/google/go-github/v52/github"
 )
 
 func ExampleOrgRepositoriesClient_Get() {

--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 // githubClientImpl is a wrapper around *github.Client, which implements higher-level methods,

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 	"github.com/gregjones/httpcache"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/github/resource_commit.go
+++ b/github/resource_commit.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )
@@ -50,7 +50,7 @@ func commitFromAPI(apiObj *github.Commit) gitprovider.CommitInfo {
 		TreeSha:   *apiObj.Tree.SHA,
 		Author:    *apiObj.Author.Name,
 		Message:   *apiObj.Message,
-		CreatedAt: *apiObj.Author.Date,
+		CreatedAt: *apiObj.Author.Date.GetTime(),
 		URL:       *apiObj.URL,
 	}
 }

--- a/github/resource_deploykey.go
+++ b/github/resource_deploykey.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/resource_organization.go
+++ b/github/resource_organization.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/resource_pullrequest.go
+++ b/github/resource_pullrequest.go
@@ -18,7 +18,7 @@ package github
 
 import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 func newPullRequest(ctx *clientContext, apiObj *github.PullRequest) *pullrequest {

--- a/github/resource_repository.go
+++ b/github/resource_repository.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/util.go
+++ b/github/util.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v52/github"
 )
 
 func Test_validateAPIObject(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/go-cmp v0.5.9
-	github.com/google/go-github/v49 v49.1.0
+	github.com/google/go-github/v52 v52.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v49 v49.1.0 h1:LFkMgawGQ8dfzWLH/rNE0b3u1D3n6/dw7ZmrN3b+YFY=
-github.com/google/go-github/v49 v49.1.0/go.mod h1:MUUzHPrhGniB6vUKa27y37likpipzG+BXXJbG04J334=
+github.com/google/go-github/v52 v52.0.0 h1:uyGWOY+jMQ8GVGSX8dkSwCzlehU3WfdxQ7GweO/JP7M=
+github.com/google/go-github/v52 v52.0.0/go.mod h1:WJV6VEEUPuMo5pXqqa2ZCZEdbQqua4zAk2MZTIo+m+4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=


### PR DESCRIPTION
### Description

If implemented workflows will use `go1.20.x`.

Update of all needed dependencies. There is a breaking change on go-github which introduce its own timeStamp struct.
 - "github.com/google/go-github/v52/github"


### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
