### PR TITLE
stash: avoid panic on err without resp

### DIFF
--- a/stash/repositories.go
+++ b/stash/repositories.go
@@ -223,7 +223,7 @@ func (s *RepositoriesService) Create(ctx context.Context, projectKey string, rep
 	}
 	res, resp, err := s.Client.Do(req)
 	if err != nil {
-		if resp.StatusCode == http.StatusConflict {
+		if resp != nil && resp.StatusCode == http.StatusConflict {
 			return nil, ErrAlreadyExists
 		}
 		return nil, fmt.Errorf("create respository failed: %w", err)


### PR DESCRIPTION
As observed in `fluxcd/pkg` tests:
https://github.com/fluxcd/pkg/actions/runs/5046501353/jobs/9052890218