### PR TITLE
Remove code coverage reporting from project

### DIFF
--- a/.github/workflows/e2e-gitea.yaml
+++ b/.github/workflows/e2e-gitea.yaml
@@ -33,7 +33,3 @@ jobs:
         run: |
           export GITEA_TOKEN=$(cat /tmp/gitea-token)
           make test-e2e-gitea
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        with:
-          files: ./coverage.txt

--- a/.github/workflows/e2e-github.yaml
+++ b/.github/workflows/e2e-github.yaml
@@ -27,7 +27,3 @@ jobs:
         run: |
           [ -n "${{ secrets.GITPROVIDER_BOT_TOKEN }}" ] && export GITHUB_TOKEN=${{ secrets.GITPROVIDER_BOT_TOKEN }} || echo "using default GITHUB_TOKEN"
           make test-e2e-github
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.2
-        with:
-          files: ./coverage.txt

--- a/.github/workflows/e2e-gitlab.yaml
+++ b/.github/workflows/e2e-gitlab.yaml
@@ -31,7 +31,3 @@ jobs:
         run: make start-provider-instances-gitlab GITLAB_VERSION=latest
       - name: Run tests [gitlab]
         run: make test-e2e-gitlab
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        with:
-          files: ./coverage.txt

--- a/.github/workflows/e2e-stash.yaml
+++ b/.github/workflows/e2e-stash.yaml
@@ -29,7 +29,3 @@ jobs:
           [ -n "${{ secrets.STASH_USER }}" ] && export STASH_USER=${{ secrets.STASH_USER }} || echo "using default STASH_USER"
           [ -n "${{ secrets.STASH_DOMAIN }}" ] && export STASH_DOMAIN=${{ secrets.STASH_DOMAIN }} || echo "using default STASH_DOMAIN"
           make test-e2e-stash
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        with:
-          files: ./coverage.txt

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![godev](https://img.shields.io/static/v1?label=godev&message=reference&color=00add8)](https://pkg.go.dev/github.com/fluxcd/go-git-providers)
 [![build](https://github.com/fluxcd/go-git-providers/workflows/build/badge.svg)](https://github.com/fluxcd/go-git-providers/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fluxcd/go-git-providers)](https://goreportcard.com/report/github.com/fluxcd/go-git-providers)
-[![codecov.io](https://codecov.io/github/fluxcd/go-git-providers/coverage.svg?branch=master)](https://codecov.io/github/fluxcd/go-git-providers?branch=master)
 [![LICENSE](https://img.shields.io/github/license/fluxcd/go-git-providers)](https://github.com/fluxcd/go-git-providers/blob/master/LICENSE)
 [![Release](https://img.shields.io/github/v/release/fluxcd/go-git-providers?include_prereleases)](https://github.com/fluxcd/go-git-providers/releases/latest)
 


### PR DESCRIPTION
No other Flux project uses Codecov (deliberately so) so this is in alignment with that sentiment.
