### PR TITLE
Validate user ref when creating user repository

### DIFF
--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -67,6 +67,9 @@ type githubClient interface {
 	// DANGEROUS COMMAND: In order to use this, you must set destructiveActions to true.
 	DeleteRepo(ctx context.Context, owner, repo string) error
 
+	// GetUser is a wrapper for "GET /user"
+	GetUser(ctx context.Context) (*github.User, error)
+
 	// ListKeys is a wrapper for "GET /repos/{owner}/{repo}/keys".
 	// This function handles pagination, HTTP error wrapping, and validates the server result.
 	ListKeys(ctx context.Context, owner, repo string) ([]*github.Key, error)
@@ -295,6 +298,12 @@ func (c *githubClientImpl) ListKeys(ctx context.Context, owner, repo string) ([]
 		}
 	}
 	return apiObjs, nil
+}
+
+func (c *githubClientImpl) GetUser(ctx context.Context) (*github.User, error) {
+	// GET /user
+	user, _, err := c.c.Users.Get(ctx, "")
+	return user, err
 }
 
 func (c *githubClientImpl) ListCommitsPage(ctx context.Context, owner, repo, branch string, perPage int, page int) ([]*github.Commit, error) {

--- a/gitlab/client_repositories_user.go
+++ b/gitlab/client_repositories_user.go
@@ -32,6 +32,19 @@ type UserRepositoriesClient struct {
 	*clientContext
 }
 
+// GetUserLogin returns the current authenticated user.
+func (c *UserRepositoriesClient) GetUserLogin(ctx context.Context) (gitprovider.IdentityRef, error) {
+	// GET /user
+	user, err := c.c.GetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &gitprovider.UserRef{
+		Domain:    c.domain,
+		UserLogin: user.Username,
+	}, nil
+}
+
 // Get returns the repository at the given path.
 //
 // ErrNotFound is returned if the resource does not exist.
@@ -87,6 +100,17 @@ func (c *UserRepositoriesClient) Create(ctx context.Context,
 	// Make sure the RepositoryRef is valid
 	if err := validateUserRepositoryRef(ref, c.domain); err != nil {
 		return nil, err
+	}
+
+	// extra validation to ensure we don't create a project when the wrong owner
+	// is passed in
+	idRef, err := c.GetUserLogin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get owner from API")
+	}
+
+	if ref.GetIdentity() != idRef.GetIdentity() {
+		return nil, gitprovider.NewErrIncorrectUser(ref.GetIdentity())
 	}
 
 	apiObj, err := createProject(ctx, c.c, ref, "", req, opts...)

--- a/gitlab/gitlabclient.go
+++ b/gitlab/gitlabclient.go
@@ -76,6 +76,9 @@ type gitlabClient interface {
 	// DANGEROUS COMMAND: In order to use this, you must set destructiveActions to true.
 	DeleteProject(ctx context.Context, projectName string) error
 
+	// GetUser is a wrapper for "GET /user"
+	GetUser(ctx context.Context) (*gitlab.User, error)
+
 	// Deploy key methods
 
 	// ListKeys is a wrapper for "GET /projects/{project}/deploy_keys".
@@ -339,6 +342,12 @@ func (c *gitlabClientImpl) DeleteProject(ctx context.Context, projectName string
 	// DELETE /projects/{project}
 	_, err := c.c.Projects.DeleteProject(projectName, gitlab.WithContext(ctx))
 	return err
+}
+
+func (c *gitlabClientImpl) GetUser(ctx context.Context) (*gitlab.User, error) {
+	// GET /user
+	proj, _, err := c.c.Users.CurrentUser(gitlab.WithContext(ctx))
+	return proj, err
 }
 
 func (c *gitlabClientImpl) ListKeys(projectName string) ([]*gitlab.ProjectDeployKey, error) {

--- a/gitprovider/client.go
+++ b/gitprovider/client.go
@@ -123,6 +123,9 @@ type UserRepositoriesClient interface {
 	// ErrAlreadyExists will be returned if the resource already exists.
 	Create(ctx context.Context, r UserRepositoryRef, req RepositoryInfo, opts ...RepositoryCreateOption) (UserRepository, error)
 
+	// GetUserLogin returns the current authenticated user.
+	GetUserLogin(ctx context.Context) (IdentityRef, error)
+
 	// Reconcile makes sure the given desired state (req) becomes the actual state in the backing Git provider.
 	//
 	// If req doesn't exist under the hood, it is created (actionTaken == true).

--- a/gitprovider/errors.go
+++ b/gitprovider/errors.go
@@ -18,6 +18,7 @@ package gitprovider
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -130,4 +131,21 @@ type ValidationErrorItem struct {
 type InvalidCredentialsError struct {
 	// InvalidCredentialsError extends HTTPError.
 	HTTPError `json:",inline"`
+}
+
+// ErrIncorrectUser describes that the user provided was incorrect
+//
+// It is returned by `UserRepositories().Create` when an incorrect UserLogin is passed in
+type ErrIncorrectUser struct {
+	user string
+}
+
+// Error implements the error interface.
+func NewErrIncorrectUser(user string) *ErrIncorrectUser {
+	return &ErrIncorrectUser{user}
+}
+
+// Error implements the error interface.
+func (e *ErrIncorrectUser) Error() string {
+	return fmt.Sprintf("incorrect user '%s' provided", e.user)
 }

--- a/stash/client_repositories_user.go
+++ b/stash/client_repositories_user.go
@@ -34,6 +34,15 @@ type UserRepositoriesClient struct {
 	*clientContext
 }
 
+// GetUserLogin returns the authenticated user.
+//
+// Stash currently doesn't have an endpoint for this, so this
+// is mostly to implement the interface.
+func (c *UserRepositoriesClient) GetUserLogin(ctx context.Context) (gitprovider.IdentityRef, error) {
+	// TODO: call API for stash
+	return gitprovider.UserRef{}, nil
+}
+
 // Get returns the repository at the given path.
 // ErrNotFound is returned if the resource does not exist.
 func (c *UserRepositoriesClient) Get(ctx context.Context, ref gitprovider.UserRepositoryRef) (gitprovider.UserRepository, error) {


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
-->
This pull request adds a function to the `UserRepositories` interface called `GetUserLogin`. It gets the current 
authenticated user associated with the token. This function is used when creating user repositories to validate 
that UserLogin. This is required because the Create API doesn't require you to pass a user and giving the wrong UserLogin
successfully creates a repository.

When running `flux bootstrap` with the wrong user (and the repository already exists) returns this confusing error because
ggp tries to create the repository under the authenticated user. 

```
flux bootstrap github --owner=soule --token-auth --repository=fleet-infra --personal
► connecting to github.com
✗ failed to create new Git repository "https://github.com/soule/fleet-infra": multiple errors occurred:
- POST https://api.github.com/user/repos: 422 Repository creation failed. [{Resource:Repository Field:name Code:custom Message:name already exists on this account}]
- resource already exists, cannot create object. Use Reconcile() to create it idempotently
```

With these changes, we give a better error
```
./bin/flux bootstrap github --owner=soule --token-auth --repository=fleet-infraxx --personal
► connecting to github.com
✗ failed to create new Git repository "https://github.com/soule/fleet-infraxx": incorrect owner 'soule' passed in

```

### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
