### PR TITLE
fix: stash and github workflows should run on pr

### DIFF
--- a/.github/workflows/e2e-github.yaml
+++ b/.github/workflows/e2e-github.yaml
@@ -2,9 +2,11 @@ name: e2e-github
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    branches: [ '*' ]
-    tags-ignore: [ '*' ]
+    branches:
+      - main
+    tags-ignore: ["*"]
 
 jobs:
   test:

--- a/.github/workflows/e2e-stash.yaml
+++ b/.github/workflows/e2e-stash.yaml
@@ -2,8 +2,10 @@ name: e2e-stash
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    branches: ["*"]
+    branches:
+      - main
     tags-ignore: ["*"]
 
 jobs:


### PR DESCRIPTION
### Description

This a fix, somehow stash and github e2e tests don't run on PR anymore.


### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->
