### PR TITLE
github: fix defer in for loop

### DIFF
--- a/github/client_repository_file.go
+++ b/github/client_repository_file.go
@@ -18,6 +18,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -58,6 +59,8 @@ func (c *FileClient) Get(ctx context.Context, path, branch string, optFns ...git
 
 	files := make([]*gitprovider.CommitFile, 0)
 
+	// For handling to close the output [io.ReadCloser] errors.
+	var errs error
 	for _, file := range directoryContent {
 		filePath := file.Path
 		output, _, err := c.c.Client().Repositories.DownloadContents(ctx, c.ref.GetIdentity(), c.ref.GetRepository(), *filePath, opts)
@@ -68,14 +71,17 @@ func (c *FileClient) Get(ctx context.Context, path, branch string, optFns ...git
 		if err != nil {
 			return nil, err
 		}
-		output.Close()
+		// Don't use defer in the for loop. Checks errors lazily.
+		errs = errors.Join(errs, output.Close())
 
 		contentStr := string(content)
 		files = append(files, &gitprovider.CommitFile{
 			Path:    filePath,
 			Content: &contentStr,
 		})
-
+	}
+	if errs != nil {
+		return nil, errs
 	}
 
 	return files, nil

--- a/github/client_repository_file.go
+++ b/github/client_repository_file.go
@@ -68,7 +68,7 @@ func (c *FileClient) Get(ctx context.Context, path, branch string, optFns ...git
 		if err != nil {
 			return nil, err
 		}
-		defer output.Close()
+		output.Close()
 
 		contentStr := string(content)
 		files = append(files, &gitprovider.CommitFile{


### PR DESCRIPTION
### Description

Fix `defer` in for loop.
In Go idioms, "defer" inside a for loop is not good.

### Test results

```console
$ go test -v -race -count=1 -shuffle=on -run=. ./github
-test.shuffle 1704783961903108000
=== RUN   Test_validateAPIObject
=== RUN   Test_validateAPIObject/no_error_=>_nil
=== RUN   Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData
--- PASS: Test_validateAPIObject (0.00s)
    --- PASS: Test_validateAPIObject/no_error_=>_nil (0.00s)
    --- PASS: Test_validateAPIObject/one_error_=>_MultiError_&_InvalidServerData (0.00s)
=== RUN   Test_allPages
=== RUN   Test_allPages/one_page_only,_no_error
=== RUN   Test_allPages/two_pages,_no_error
=== RUN   Test_allPages/four_pages,_error_at_second
--- PASS: Test_allPages (0.00s)
    --- PASS: Test_allPages/one_page_only,_no_error (0.00s)
    --- PASS: Test_allPages/two_pages,_no_error (0.00s)
    --- PASS: Test_allPages/four_pages,_error_at_second (0.00s)
=== RUN   Test_getPermissionFromMap
=== RUN   Test_getPermissionFromMap/pull
=== RUN   Test_getPermissionFromMap/push
=== RUN   Test_getPermissionFromMap/admin
=== RUN   Test_getPermissionFromMap/none
=== RUN   Test_getPermissionFromMap/false_data
=== RUN   Test_getPermissionFromMap/not_all_specifed
--- PASS: Test_getPermissionFromMap (0.00s)
    --- PASS: Test_getPermissionFromMap/pull (0.00s)
    --- PASS: Test_getPermissionFromMap/push (0.00s)
    --- PASS: Test_getPermissionFromMap/admin (0.00s)
    --- PASS: Test_getPermissionFromMap/none (0.00s)
    --- PASS: Test_getPermissionFromMap/false_data (0.00s)
    --- PASS: Test_getPermissionFromMap/not_all_specifed (0.00s)
=== RUN   Test_DomainVariations
=== RUN   Test_DomainVariations/github.com_domain
=== RUN   Test_DomainVariations/custom_domain_without_protocol
=== RUN   Test_DomainVariations/custom_domain_with_https_protocol
=== RUN   Test_DomainVariations/custom_domain_with_http_protocol
--- PASS: Test_DomainVariations (0.00s)
    --- PASS: Test_DomainVariations/github.com_domain (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_without_protocol (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_with_https_protocol (0.00s)
    --- PASS: Test_DomainVariations/custom_domain_with_http_protocol (0.00s)
=== RUN   ExampleOrganizationsClient_Get
--- PASS: ExampleOrganizationsClient_Get (0.22s)
=== RUN   ExampleOrgRepositoriesClient_Get
--- PASS: ExampleOrgRepositoriesClient_Get (0.23s)
PASS
ok      github.com/fluxcd/go-git-providers/github       1.477s
```