### PR TITLE
Update `go-github` to v61

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -19,7 +19,7 @@ package github
 import (
 	"fmt"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client.go
+++ b/github/client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_organization_teams.go
+++ b/github/client_organization_teams.go
@@ -19,7 +19,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repositories_org.go
+++ b/github/client_repositories_org.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repository_branch.go
+++ b/github/client_repository_branch.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // BranchClient implements the gitprovider.BranchClient interface.

--- a/github/client_repository_commit.go
+++ b/github/client_repository_commit.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 var githubNewFileMode = "100644"

--- a/github/client_repository_deploykey.go
+++ b/github/client_repository_deploykey.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/client_repository_file.go
+++ b/github/client_repository_file.go
@@ -23,7 +23,7 @@ import (
 	"io"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // FileClient implements the gitprovider.FileClient interface.

--- a/github/client_repository_pullrequest.go
+++ b/github/client_repository_pullrequest.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // PullRequestClient implements the gitprovider.PullRequestClient interface.

--- a/github/example_organization_test.go
+++ b/github/example_organization_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogithub "github.com/google/go-github/v57/github"
+	gogithub "github.com/google/go-github/v61/github"
 )
 
 // checkErr is used for examples in this repository.

--- a/github/example_repository_test.go
+++ b/github/example_repository_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogithub "github.com/google/go-github/v57/github"
+	gogithub "github.com/google/go-github/v61/github"
 )
 
 func ExampleOrgRepositoriesClient_Get() {

--- a/github/githubclient.go
+++ b/github/githubclient.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 // githubClientImpl is a wrapper around *github.Client, which implements higher-level methods,

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 	"github.com/gregjones/httpcache"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/github/resource_commit.go
+++ b/github/resource_commit.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/github/resource_deploykey.go
+++ b/github/resource_deploykey.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/resource_organization.go
+++ b/github/resource_organization.go
@@ -17,7 +17,7 @@ limitations under the License.
 package github
 
 import (
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/resource_pullrequest.go
+++ b/github/resource_pullrequest.go
@@ -18,7 +18,7 @@ package github
 
 import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 func newPullRequest(ctx *clientContext, apiObj *github.PullRequest) *pullrequest {

--- a/github/resource_repository.go
+++ b/github/resource_repository.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/util.go
+++ b/github/util.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"
-	"github.com/google/go-github/v57/github"
+	"github.com/google/go-github/v61/github"
 )
 
 func Test_validateAPIObject(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v57 v57.0.0
+	github.com/google/go-github/v61 v61.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -778,8 +778,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v57 v57.0.0 h1:L+Y3UPTY8ALM8x+TV0lg+IEBI+upibemtBD8Q9u7zHs=
-github.com/google/go-github/v57 v57.0.0/go.mod h1:s0omdnye0hvK/ecLvpsGfJMiRt85PimQh4oygmLIxHw=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=


### PR DESCRIPTION
### Description

update github.com/google/go-github to v61

