### PR TITLE
Skip running e2e tests on dependabot PRs

### DIFF
--- a/.github/workflows/e2e-gitea.yaml
+++ b/.github/workflows/e2e-gitea.yaml
@@ -11,6 +11,7 @@ name: e2e-gitea
 
 jobs:
   test:
+    if: github.actor != 'dependabot[bot]'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-github.yaml
+++ b/.github/workflows/e2e-github.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-gitlab.yaml
+++ b/.github/workflows/e2e-gitlab.yaml
@@ -11,6 +11,7 @@ name: e2e-gitlab
 
 jobs:
   test:
+    if: github.actor != 'dependabot[bot]'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-stash.yaml
+++ b/.github/workflows/e2e-stash.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Dependabot PRs don't have permission to access certain resources such as repo/org secrets so the e2e tests will always fail on those PRs.

It doesn't make a lot of sense to run e2e tests on dependabot PRs, anyway, as we only let dependabot bump actions which don't have any impact on the functionality of the library.