### PR TITLE
Migrate to new GitLab client-go

### DIFF
--- a/gitlab/auth.go
+++ b/gitlab/auth.go
@@ -18,7 +18,7 @@ package gitlab
 
 import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogitlab "github.com/xanzy/go-gitlab"
+	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 const (

--- a/gitlab/client.go
+++ b/gitlab/client.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // ProviderID is the provider ID for GitLab.

--- a/gitlab/client_organization_teams.go
+++ b/gitlab/client_organization_teams.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // TeamsClient implements the gitprovider.TeamsClient interface.

--- a/gitlab/client_repositories_org.go
+++ b/gitlab/client_repositories_org.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // OrgRepositoriesClient implements the gitprovider.OrgRepositoriesClient interface.

--- a/gitlab/client_repository_branch.go
+++ b/gitlab/client_repository_branch.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // BranchClient implements the gitprovider.BranchClient interface.

--- a/gitlab/client_repository_commit.go
+++ b/gitlab/client_repository_commit.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // CommitClient implements the gitprovider.CommitClient interface.

--- a/gitlab/client_repository_deploykey.go
+++ b/gitlab/client_repository_deploykey.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // DeployKeyClient implements the gitprovider.DeployKeyClient interface.

--- a/gitlab/client_repository_deploytoken.go
+++ b/gitlab/client_repository_deploytoken.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // DeployTokenClient implements the gitprovider.DeployTokenClient interface.

--- a/gitlab/client_repository_file.go
+++ b/gitlab/client_repository_file.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // FileClient implements the gitprovider.FileClient interface.

--- a/gitlab/client_repository_pullrequest.go
+++ b/gitlab/client_repository_pullrequest.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // mergeStatusChecking indicates that gitlab has not yet asynchronously updated the merge status for a merge request

--- a/gitlab/client_repository_tree.go
+++ b/gitlab/client_repository_tree.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // TreeClient implements the gitprovider.TreeClient interface.

--- a/gitlab/example_organization_test.go
+++ b/gitlab/example_organization_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitlab"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogitlab "github.com/xanzy/go-gitlab"
+	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 // checkErr is used for examples in this repository.

--- a/gitlab/example_repository_test.go
+++ b/gitlab/example_repository_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitlab"
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	gogitlab "github.com/xanzy/go-gitlab"
+	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 func ExampleOrgRepositoriesClient_Get() {

--- a/gitlab/gitlabclient.go
+++ b/gitlab/gitlabclient.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // gitlabClientImpl is a wrapper around *github.Client, which implements higher-level methods,

--- a/gitlab/integration_test.go
+++ b/gitlab/integration_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gregjones/httpcache"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	testutils "github.com/fluxcd/go-git-providers/gitprovider/testutils"

--- a/gitlab/resource_commit.go
+++ b/gitlab/resource_commit.go
@@ -17,7 +17,7 @@ limitations under the License.
 package gitlab
 
 import (
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/gitlab/resource_deploykey.go
+++ b/gitlab/resource_deploykey.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/gitlab/resource_deploytoken.go
+++ b/gitlab/resource_deploytoken.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/gitlab/resource_organization.go
+++ b/gitlab/resource_organization.go
@@ -17,7 +17,7 @@ limitations under the License.
 package gitlab
 
 import (
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/gitlab/resource_pullrequest.go
+++ b/gitlab/resource_pullrequest.go
@@ -18,7 +18,7 @@ package gitlab
 
 import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 // The value of the "State" field of a gitlab merge request after it has been merged"

--- a/gitlab/resource_repository.go
+++ b/gitlab/resource_repository.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 
 	"github.com/google/go-cmp/cmp"
-	gogitlab "github.com/xanzy/go-gitlab"
+	gogitlab "gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 )

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"

--- a/gitlab/util_test.go
+++ b/gitlab/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/fluxcd/go-git-providers/validation"
-	"github.com/xanzy/go-gitlab"
+	"gitlab.com/gitlab-org/api/client-go"
 )
 
 func Test_validateAPIObject(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ktrysmt/go-bitbucket v0.9.81
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.36.1
-	github.com/xanzy/go-gitlab v0.114.0
+	gitlab.com/gitlab-org/api/client-go v0.116.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.30.0
 	golang.org/x/oauth2 v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -154,12 +154,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/xanzy/go-gitlab v0.114.0 h1:0wQr/KBckwrZPfEMjRqpUz0HmsKKON9UhCYv9KDy19M=
-github.com/xanzy/go-gitlab v0.114.0/go.mod h1:wKNKh3GkYDMOsGmnfuX+ITCmDuSDWFO0G+C4AygL9RY=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+gitlab.com/gitlab-org/api/client-go v0.116.0 h1:Dy534gtZPMrnm3fAcmQRMadrcoUyFO4FQ4rXlSAdHAw=
+gitlab.com/gitlab-org/api/client-go v0.116.0/go.mod h1:B29OfnZklmaoiR7uHANh9jTyfWEgmXvZLVEnosw2Dx0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=


### PR DESCRIPTION
### Description

go-gitlab moves to gitlab.com: https://github.com/xanzy/go-gitlab/issues/2060. The latest releases of https://gitlab.com/gitlab-org/api/client-go require Go 1.23, and I don't want to miss a Go upgrade into this PR.

### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->

Somehow tests are failing on my workstation, but it's failing with the same errors without this change. 🤔 Might be something strange in my corporate environment.

````
$ make test
go mod tidy -compat=1.22
go fmt ./...
go vet ./...
go test  -race -coverprofile=coverage.txt -covermode=atomic ./...
?       github.com/fluxcd/go-git-providers/bitbucket    [no test files]
        github.com/fluxcd/go-git-providers/gitprovider/cache            coverage: 0.0% of statements
        github.com/fluxcd/go-git-providers/gitprovider/testutils                coverage: 0.0% of statements
2024/12/28 13:10:25 failed to create Gitea client: unknown version: f943dcdc4
FAIL    github.com/fluxcd/go-git-providers/gitea        1.092s
ok      github.com/fluxcd/go-git-providers/github       2.025s  coverage: 12.9% of statements
ok      github.com/fluxcd/go-git-providers/gitlab       1.048s  coverage: 5.6% of statements
--- FAIL: Test_makeCientOptions (0.01s)
    --- FAIL: Test_makeCientOptions/WithCustomCAPostChainTransportHook (0.00s)
        client_options_test.go:308: makeOptions() = &{{<nil> <nil> <nil> 0x849d60 <nil> [45 45 45 45 45 66 69 71 73 78 32 67 69 82 84 73 70 73 67 65 84 69 45 45 45 45 45 10 77 73 73 66 104 122 67 67 65 83 50 103 65 119 73 66 65 103 73 85 100 115 65 116 105 88 51 103 78 48 117 107 55 100 100 120 65 83 87 89 69 47 116 100 118 48 119 119 67 103 89 73 75 111 90 73 122 106 48 69 65 119 73 119 10 71 84 69 88 77 66 85 71 65 49 85 69 65 120 77 79 90 88 104 104 98 88 66 115 90 83 53 106 98 50 48 103 81 48 69 119 72 104 99 78 77 106 65 119 78 68 69 51 77 68 103 120 79 68 65 119 87 104 99 78 77 106 85 119 10 78 68 69 50 77 68 103 120 79 68 65 119 87 106 65 90 77 82 99 119 70 81 89 68 86 81 81 68 69 119 53 108 101 71 70 116 99 71 120 108 76 109 78 118 98 83 66 68 81 84 66 90 77 66 77 71 66 121 113 71 83 77 52 57 10 65 103 69 71 67 67 113 71 83 77 52 57 65 119 69 72 65 48 73 65 66 75 55 104 47 53 68 56 98 86 57 51 77 109 69 100 104 117 48 50 74 115 83 54 117 103 66 56 115 54 80 122 82 108 51 80 86 52 120 115 51 83 98 114 10 82 78 107 107 77 53 57 43 120 51 98 48 105 87 120 47 105 55 54 113 80 89 112 78 76 111 105 86 85 86 88 81 109 65 57 89 43 52 68 98 77 120 105 106 85 122 66 82 77 65 52 71 65 49 85 100 68 119 69 66 47 119 81 69 10 65 119 73 66 66 106 65 80 66 103 78 86 72 82 77 66 65 102 56 69 66 84 65 68 65 81 72 47 77 66 48 71 65 49 85 100 68 103 81 87 66 66 81 71 121 85 105 85 49 81 69 90 105 77 65 113 106 115 110 73 89 84 119 90 10 52 121 112 53 119 122 65 80 66 103 78 86 72 82 69 69 67 68 65 71 104 119 82 47 65 65 65 66 77 65 111 71 67 67 113 71 83 77 52 57 66 65 77 67 65 48 103 65 77 69 85 67 73 81 68 122 100 116 118 75 100 69 56 79 10 49 43 87 82 84 90 57 77 117 83 105 70 89 99 114 69 122 55 90 110 101 55 86 88 111 117 68 69 75 113 75 69 105 103 73 103 77 52 87 108 98 68 101 117 78 67 75 98 113 104 113 106 43 120 90 86 48 112 97 51 114 119 101 98 10 79 68 56 69 106 106 67 77 89 54 57 82 77 79 48 61 10 45 45 45 45 45 69 78 68 32 67 69 82 84 73 70 73 67 65 84 69 45 45 45 45 45 10]} <nil> <nil>}, want &{{<nil> <nil> <nil> 0x8567e0 <nil> [45 45 45 45 45 66 69 71 73 78 32 67 69 82 84 73 70 73 67 65 84 69 45 45 45 45 45 10 77 73 73 66 104 122 67 67 65 83 50 103 65 119 73 66 65 103 73 85 100 115 65 116 105 88 51 103 78 48 117 107 55 100 100 120 65 83 87 89 69 47 116 100 118 48 119 119 67 103 89 73 75 111 90 73 122 106 48 69 65 119 73 119 10 71 84 69 88 77 66 85 71 65 49 85 69 65 120 77 79 90 88 104 104 98 88 66 115 90 83 53 106 98 50 48 103 81 48 69 119 72 104 99 78 77 106 65 119 78 68 69 51 77 68 103 120 79 68 65 119 87 104 99 78 77 106 85 119 10 78 68 69 50 77 68 103 120 79 68 65 119 87 106 65 90 77 82 99 119 70 81 89 68 86 81 81 68 69 119 53 108 101 71 70 116 99 71 120 108 76 109 78 118 98 83 66 68 81 84 66 90 77 66 77 71 66 121 113 71 83 77 52 57 10 65 103 69 71 67 67 113 71 83 77 52 57 65 119 69 72 65 48 73 65 66 75 55 104 47 53 68 56 98 86 57 51 77 109 69 100 104 117 48 50 74 115 83 54 117 103 66 56 115 54 80 122 82 108 51 80 86 52 120 115 51 83 98 114 10 82 78 107 107 77 53 57 43 120 51 98 48 105 87 120 47 105 55 54 113 80 89 112 78 76 111 105 86 85 86 88 81 109 65 57 89 43 52 68 98 77 120 105 106 85 122 66 82 77 65 52 71 65 49 85 100 68 119 69 66 47 119 81 69 10 65 119 73 66 66 106 65 80 66 103 78 86 72 82 77 66 65 102 56 69 66 84 65 68 65 81 72 47 77 66 48 71 65 49 85 100 68 103 81 87 66 66 81 71 121 85 105 85 49 81 69 90 105 77 65 113 106 115 110 73 89 84 119 90 10 52 121 112 53 119 122 65 80 66 103 78 86 72 82 69 69 67 68 65 71 104 119 82 47 65 65 65 66 77 65 111 71 67 67 113 71 83 77 52 57 66 65 77 67 65 48 103 65 77 69 85 67 73 81 68 122 100 116 118 75 100 69 56 79 10 49 43 87 82 84 90 57 77 117 83 105 70 89 99 114 69 122 55 90 110 101 55 86 88 111 117 68 69 75 113 75 69 105 103 73 103 77 52 87 108 98 68 101 117 78 67 75 98 113 104 113 106 43 120 90 86 48 112 97 51 114 119 101 98 10 79 68 56 69 106 106 67 77 89 54 57 82 77 79 48 61 10 45 45 45 45 45 69 78 68 32 67 69 82 84 73 70 73 67 65 84 69 45 45 45 45 45 10]} <nil> <nil>}
    --- FAIL: Test_makeCientOptions/WithOAuth2Token (0.00s)
        client_options_test.go:304: unexpected authTransport, got (gitprovider.ChainableRoundTripperFunc)(0x8494e0), want (gitprovider.ChainableRoundTripperFunc)(0x856600)
FAIL
coverage: 87.0% of statements
FAIL    github.com/fluxcd/go-git-providers/gitprovider  0.055s
ok      github.com/fluxcd/go-git-providers/stash        6.988s  coverage: 34.0% of statements
ok      github.com/fluxcd/go-git-providers/validation   0.836s  coverage: 100.0% of statements
FAIL
make: *** [Makefile:44: test] Error 1
````