### PR TITLE
Update misleading GitLab client comments

### DIFF
--- a/gitlab/client.go
+++ b/gitlab/client.go
@@ -90,7 +90,7 @@ func (c *Client) ProviderID() gitprovider.ProviderID {
 	return ProviderID
 }
 
-// Raw returns the Go GitLab client (github.com/xanzy *Client)
+// Raw returns the Go GitLab client (gitlab.com/gitlab-org/api/client-go *Client)
 // used under the hood for accessing GitLab.
 func (c *Client) Raw() interface{} {
 	return c.c.Client()

--- a/gitlab/example_organization_test.go
+++ b/gitlab/example_organization_test.go
@@ -35,7 +35,7 @@ func ExampleOrganizationsClient_Get() {
 
 	// Use .Get() to aquire a high-level gitprovider.OrganizationInfo struct
 	orgInfo := org.Get()
-	// Cast the internal object to a *gogithub.Organization to access custom data
+	// Cast the internal object to a *gogitlab.Group to access custom data
 	internalOrg := org.APIObject().(*gogitlab.Group)
 
 	fmt.Printf("Name: %s. Location: %s.", *orgInfo.Name, internalOrg.Path)

--- a/gitlab/example_repository_test.go
+++ b/gitlab/example_repository_test.go
@@ -28,7 +28,7 @@ func ExampleOrgRepositoriesClient_Get() {
 
 	// Use .Get() to aquire a high-level gitprovider.OrganizationInfo struct
 	repoInfo := repo.Get()
-	// Cast the internal object to a *gogithub.Repository to access custom data
+	// Cast the internal object to a *gogitlab.Project to access custom data
 	internalRepo := repo.APIObject().(*gogitlab.Project)
 
 	fmt.Printf("Description: %s. Homepage: %s", *repoInfo.Description, internalRepo.HTTPURLToRepo)

--- a/gitlab/gitlabclient.go
+++ b/gitlab/gitlabclient.go
@@ -25,12 +25,12 @@ import (
 	"gitlab.com/gitlab-org/api/client-go"
 )
 
-// gitlabClientImpl is a wrapper around *github.Client, which implements higher-level methods,
-// operating on the go-github structs. Pagination is implemented for all List* methods, all returned
+// gitlabClientImpl is a wrapper around *gitlab.Client, which implements higher-level methods,
+// operating on the go-gitlab structs. Pagination is implemented for all List* methods, all returned
 // objects are validated, and HTTP errors are handled/wrapped using handleHTTPError.
 // This interface is also fakeable, in order to unit-test the client.
 type gitlabClient interface {
-	// Client returns the underlying *github.Client
+	// Client returns the underlying *gitlab.Client
 	Client() *gitlab.Client
 
 	// Group methods

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -130,7 +130,7 @@ func allDeployTokenPages(opts *gitlab.ListProjectDeployTokensOptions, fn func() 
 	}
 }
 
-// validateUserRepositoryRef makes sure the UserRepositoryRef is valid for GitHub's usage.
+// validateUserRepositoryRef makes sure the UserRepositoryRef is valid for GitLab's usage.
 func validateUserRepositoryRef(ref gitprovider.UserRepositoryRef, expectedDomain string) error {
 	// Make sure the RepositoryRef fields are valid
 	if err := validation.ValidateTargets("UserRepositoryRef", ref); err != nil {
@@ -140,7 +140,7 @@ func validateUserRepositoryRef(ref gitprovider.UserRepositoryRef, expectedDomain
 	return validateIdentityFields(ref, expectedDomain)
 }
 
-// validateOrgRepositoryRef makes sure the OrgRepositoryRef is valid for GitHub's usage.
+// validateOrgRepositoryRef makes sure the OrgRepositoryRef is valid for GitLab's usage.
 func validateOrgRepositoryRef(ref gitprovider.OrgRepositoryRef, expectedDomain string) error {
 	// Make sure the RepositoryRef fields are valid
 	if err := validation.ValidateTargets("OrgRepositoryRef", ref); err != nil {
@@ -150,7 +150,7 @@ func validateOrgRepositoryRef(ref gitprovider.OrgRepositoryRef, expectedDomain s
 	return validateIdentityFields(ref, expectedDomain)
 }
 
-// validateUserRef makes sure the UserRef is valid for GitHub's usage.
+// validateUserRef makes sure the UserRef is valid for GitLab's usage.
 func validateUserRef(ref gitprovider.UserRef, expectedDomain string) error {
 	// Make sure the OrganizationRef fields are valid
 	if err := validation.ValidateTargets("UserRef", ref); err != nil {
@@ -192,7 +192,7 @@ func validateProjectAPI(apiObj *gitlab.Project) error {
 	})
 }
 
-// validateOrganizationRef makes sure the OrganizationRef is valid for GitHub's usage.
+// validateOrganizationRef makes sure the OrganizationRef is valid for GitLab's usage.
 func validateOrganizationRef(ref gitprovider.OrganizationRef, expectedDomain string) error {
 	// Make sure the OrganizationRef fields are valid
 	if err := validation.ValidateTargets("OrganizationRef", ref); err != nil {


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
-->

This fixes some misleading comments in the GitLab client. The GitHub references are probably copy-pasted from the GitHub client. I am also updating a comment referring to the old GitLab client module replaced in https://github.com/fluxcd/go-git-providers/pull/307.
I should have fixed this in https://github.com/fluxcd/go-git-providers/pull/307, but I noticed this after the PR was merged.

### Test results

<!--
Post here the "make test" result.
This is required for your PR to be reviewed.
-->

N/A
