### PR TITLE
stash: fix dropped errors

### DIFF
--- a/stash/client_repositories_org.go
+++ b/stash/client_repositories_org.go
@@ -256,7 +256,9 @@ func createRepository(ctx context.Context, c *Client, orgKey string, ref gitprov
 			return nil, fmt.Errorf("failed to create initial commit: %w", err)
 		}
 
-		err = initRepo(ctx, c, initCommit, repo)
+		if err := initRepo(ctx, c, initCommit, repo); err != nil {
+			return nil, fmt.Errorf("failed to initialize repository: %w", err)
+		}
 
 		if data.DefaultBranch != "" && data.DefaultBranch != legacyBranch {
 			//create default branch

--- a/stash/client_repository_branch.go
+++ b/stash/client_repository_branch.go
@@ -71,7 +71,9 @@ func (c *BranchClient) Create(ctx context.Context, branch, sha string) error {
 		}),
 		WithMessage("Create branch"),
 		WithURL(url))
-
+	if err != nil {
+		return fmt.Errorf("branch client failed to instantiate commit: %w", err)
+	}
 	_, err = c.client.Git.CreateCommit(dir, r, "", commit)
 	if err != nil {
 		return fmt.Errorf("failed to create commit: %w", err)

--- a/stash/client_repository_commit.go
+++ b/stash/client_repository_commit.go
@@ -107,6 +107,10 @@ func (c *CommitClient) Create(ctx context.Context, branch string, message string
 		WithURL(url),
 		WithFiles(f))
 
+	if err != nil {
+		return nil, fmt.Errorf("commit client failed to instantiate commit: %w", err)
+	}
+
 	result, err := c.client.Git.CreateCommit(dir, r, branch, commit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create commit: %w", err)

--- a/stash/pull_requests.go
+++ b/stash/pull_requests.go
@@ -362,6 +362,9 @@ func (s *PullRequestsService) Merge(ctx context.Context, projectKey, repositoryS
 func (s *PullRequestsService) Delete(ctx context.Context, projectKey, repositorySlug string, IDVersion IDVersion) error {
 	header := http.Header{"Content-Type": []string{"application/json"}}
 	body, err := marshallBody(IDVersion.Version)
+	if err != nil {
+		return fmt.Errorf("marshal ID version failed: %w", err)
+	}
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, newURI(projectsURI, projectKey, RepositoriesURI, repositorySlug, pullRequestsURI, strconv.Itoa(IDVersion.ID)), WithBody(body), WithHeader(header))
 	if err != nil {
 		return fmt.Errorf("delete pull request frequest creation failed: %w", err)


### PR DESCRIPTION
This fixes dropped `err` variables in `stash`. Running `go test ./...` from the `stash` directory continues to pass.